### PR TITLE
feat: per-split-board chip selection and chip-specific config overrides

### DIFF
--- a/rmk-config/src/chip.rs
+++ b/rmk-config/src/chip.rs
@@ -1,4 +1,4 @@
-use crate::{ChipConfig, KeyboardTomlConfig};
+use crate::{ChipConfig, KeyboardTomlConfig, SplitBoardConfig};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum ChipSeries {
@@ -59,6 +59,56 @@ impl ChipModel {
     }
 }
 
+/// Build a `ChipModel` from a raw chip name string.
+pub fn parse_chip_model(chip: &str) -> Result<ChipModel, String> {
+    let lower = chip.to_lowercase();
+    if lower.starts_with("stm32") {
+        Ok(ChipModel {
+            series: ChipSeries::Stm32,
+            chip: chip.to_string(),
+            board: None,
+        })
+    } else if lower.starts_with("nrf52") {
+        Ok(ChipModel {
+            series: ChipSeries::Nrf52,
+            chip: chip.to_string(),
+            board: None,
+        })
+    } else if lower.starts_with("rp2040") {
+        Ok(ChipModel {
+            series: ChipSeries::Rp2040,
+            chip: chip.to_string(),
+            board: None,
+        })
+    } else if lower.starts_with("esp32") {
+        Ok(ChipModel {
+            series: ChipSeries::Esp32,
+            chip: chip.to_string(),
+            board: None,
+        })
+    } else {
+        Err(format!("Unsupported chip: {}", chip))
+    }
+}
+
+/// Build a `ChipModel` from a supported board name.
+fn chip_model_from_board(board: &str) -> Result<ChipModel, String> {
+    match board {
+        "nice!nano" | "nice!nano_v1" | "nicenano" | "nice!nano_v2" | "nice!nano v2" | "XIAO BLE"
+        | "nrfmicro" | "bluemicro840" | "puchi_ble" => Ok(ChipModel {
+            series: ChipSeries::Nrf52,
+            chip: "nrf52840".to_string(),
+            board: Some(board.to_string()),
+        }),
+        "Pi Pico W" | "Pico W" | "pi_pico_w" | "pico_w" => Ok(ChipModel {
+            series: ChipSeries::Rp2040,
+            chip: "rp2040".to_string(),
+            board: Some(board.to_string()),
+        }),
+        _ => Err(format!("Unsupported board: {}", board)),
+    }
+}
+
 impl KeyboardTomlConfig {
     pub(crate) fn get_chip_model(&self) -> Result<ChipModel, String> {
         let keyboard = self.keyboard.as_ref().unwrap();
@@ -66,50 +116,10 @@ impl KeyboardTomlConfig {
             return Err("Either \"board\" or \"chip\" should be set in keyboard.toml, but not both".to_string());
         }
 
-        // Check board type
         if let Some(board) = keyboard.board.clone() {
-            match board.as_str() {
-                "nice!nano" | "nice!nano_v1" | "nicenano" | "nice!nano_v2" | "nice!nano v2" | "XIAO BLE"
-                | "nrfmicro" | "bluemicro840" | "puchi_ble" => Ok(ChipModel {
-                    series: ChipSeries::Nrf52,
-                    chip: "nrf52840".to_string(),
-                    board: Some(board),
-                }),
-                "Pi Pico W" | "Pico W" | "pi_pico_w" | "pico_w" => Ok(ChipModel {
-                    series: ChipSeries::Rp2040,
-                    chip: "rp2040".to_string(),
-                    board: Some(board),
-                }),
-                _ => Err(format!("Unsupported board: {}", board)),
-            }
+            chip_model_from_board(&board)
         } else if let Some(chip) = keyboard.chip.clone() {
-            if chip.to_lowercase().starts_with("stm32") {
-                Ok(ChipModel {
-                    series: ChipSeries::Stm32,
-                    chip,
-                    board: None,
-                })
-            } else if chip.to_lowercase().starts_with("nrf52") {
-                Ok(ChipModel {
-                    series: ChipSeries::Nrf52,
-                    chip,
-                    board: None,
-                })
-            } else if chip.to_lowercase().starts_with("rp2040") {
-                Ok(ChipModel {
-                    series: ChipSeries::Rp2040,
-                    chip,
-                    board: None,
-                })
-            } else if chip.to_lowercase().starts_with("esp32") {
-                Ok(ChipModel {
-                    series: ChipSeries::Esp32,
-                    chip,
-                    board: None,
-                })
-            } else {
-                Err(format!("Unsupported chip: {}", chip))
-            }
+            parse_chip_model(&chip)
         } else {
             Err("Neither board nor chip is specified".to_string())
         }
@@ -117,10 +127,30 @@ impl KeyboardTomlConfig {
 
     pub(crate) fn get_chip_config(&self) -> ChipConfig {
         let chip_name = &self.get_chip_model().unwrap().chip;
+        self.get_chip_config_for(chip_name)
+    }
+
+    pub(crate) fn get_chip_config_for(&self, chip_name: &str) -> ChipConfig {
         self.chip
             .as_ref()
             .and_then(|chip_configs| chip_configs.get(chip_name))
             .cloned()
             .unwrap_or_default()
+    }
+
+    /// Resolve the chip model for a split board.
+    ///
+    /// If the board defines its own `chip`, use it; otherwise fall back to the
+    /// top-level keyboard chip model.
+    pub fn resolve_split_board_chip(
+        &self,
+        board_config: &SplitBoardConfig,
+        fallback: &ChipModel,
+    ) -> ChipModel {
+        board_config
+            .chip
+            .as_ref()
+            .map(|chip| parse_chip_model(chip).expect("Invalid split board chip"))
+            .unwrap_or_else(|| fallback.clone())
     }
 }

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -503,7 +503,7 @@ pub const DEFAULT_PASSKEY_ENTRY_TIMEOUT_SECS: u32 = 120;
 pub const MIN_PASSKEY_ENTRY_TIMEOUT_SECS: u32 = 30;
 
 /// Config for chip-specific settings
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ChipConfig {
     /// DCDC regulator 0 enabled (for nrf52840)
@@ -764,6 +764,9 @@ pub struct SplitBoardConfig {
     pub row_offset: usize,
     /// Col offset of the split board
     pub col_offset: usize,
+    /// Chip model for this split board.
+    /// If not set, the top-level keyboard chip is used.
+    pub chip: Option<String>,
     /// Ble address
     pub ble_addr: Option<[u8; 6]>,
     /// Serial config, the vector length should be 1 for peripheral
@@ -1228,5 +1231,121 @@ subs = 2
         assert_eq!(config.event.layer_change.channel_size, 1);
         assert_eq!(config.event.layer_change.pubs, 2);
         assert_eq!(config.event.layer_change.subs, 2);
+    }
+
+    #[test]
+    fn test_split_board_chip_defaults_to_top_level_chip() {
+        let user_toml = r#"
+[keyboard]
+name = "Test"
+vendor_id = 0x1234
+product_id = 0x5678
+chip = "nrf52840"
+
+[layout]
+rows = 4
+cols = 3
+layers = 1
+keymap = [[["A", "B", "C"], ["D", "E", "F"], ["G", "H", "I"], ["J", "K", "L"]]]
+
+[split]
+connection = "ble"
+
+[split.central]
+rows = 2
+cols = 2
+row_offset = 0
+col_offset = 0
+
+[split.central.matrix]
+matrix_type = "normal"
+row_pins = ["P0_00", "P0_01"]
+col_pins = ["P0_02", "P0_03"]
+
+[[split.peripheral]]
+rows = 2
+cols = 1
+row_offset = 2
+col_offset = 2
+
+[split.peripheral.matrix]
+matrix_type = "normal"
+row_pins = ["P0_04", "P0_05"]
+col_pins = ["P0_06"]
+"#;
+        let config: KeyboardTomlConfig = Config::builder()
+            .add_source(File::from_str(user_toml, FileFormat::Toml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let top_level_chip = config.get_chip_model().unwrap();
+        let peripheral = &config.split.as_ref().unwrap().peripheral[0];
+        let resolved = config.resolve_split_board_chip(peripheral, &top_level_chip);
+        assert_eq!(resolved, top_level_chip);
+    }
+
+    #[test]
+    fn test_split_board_chip_override() {
+        let user_toml = r#"
+[keyboard]
+name = "Test"
+vendor_id = 0x1234
+product_id = 0x5678
+chip = "nrf52840"
+
+[layout]
+rows = 4
+cols = 3
+layers = 1
+keymap = [[["A", "B", "C"], ["D", "E", "F"], ["G", "H", "I"], ["J", "K", "L"]]]
+
+[ble]
+enabled = true
+
+[split]
+connection = "ble"
+
+[split.central]
+rows = 2
+cols = 2
+row_offset = 0
+col_offset = 0
+
+[split.central.matrix]
+matrix_type = "normal"
+row_pins = ["P0_00", "P0_01"]
+col_pins = ["P0_02", "P0_03"]
+
+[[split.peripheral]]
+chip = "rp2040"
+rows = 2
+cols = 1
+row_offset = 2
+col_offset = 2
+
+[split.peripheral.matrix]
+matrix_type = "normal"
+row_pins = ["PIN_4", "PIN_5"]
+col_pins = ["PIN_6"]
+"#;
+        let config: KeyboardTomlConfig = Config::builder()
+            .add_source(File::from_str(user_toml, FileFormat::Toml))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let top_level_chip = config.get_chip_model().unwrap();
+        let peripheral = &config.split.as_ref().unwrap().peripheral[0];
+        let resolved = config.resolve_split_board_chip(peripheral, &top_level_chip);
+        assert_eq!(resolved.series, chip::ChipSeries::Rp2040);
+        assert_eq!(resolved.chip, "rp2040");
+
+        let hardware = config.hardware().unwrap();
+        let (peripheral_chip, peripheral_chip_config) = hardware.chip_for_split_board(peripheral);
+        assert_eq!(peripheral_chip.series, chip::ChipSeries::Rp2040);
+        assert_eq!(peripheral_chip_config, ChipConfig::default());
     }
 }

--- a/rmk-config/src/resolved/hardware.rs
+++ b/rmk-config/src/resolved/hardware.rs
@@ -3,9 +3,11 @@
 //! Leaf types are re-exported directly from the TOML configuration types
 //! Only types with genuine structural transformation are defined here.
 
+use std::collections::HashMap;
+
 // Re-export leaf types from TOML config (now properly named and `pub`)
 pub use crate::board::{BoardConfig, UniBodyConfig};
-pub use crate::chip::{ChipModel, ChipSeries};
+pub use crate::chip::{ChipModel, ChipSeries, parse_chip_model};
 pub use crate::communication::{CommunicationConfig, UsbInfo};
 pub use crate::{
     BleConfig, ChipConfig, CommunicationProtocol, DependencyConfig, DisplayConfig, DisplayDriver, EncoderConfig,
@@ -26,6 +28,8 @@ pub struct Storage {
 pub struct Hardware {
     pub chip: ChipModel,
     pub chip_config: ChipConfig,
+    /// User-supplied `[chip.<name>]` overrides for all chips used in the build.
+    pub chip_configs: HashMap<String, ChipConfig>,
     pub communication: CommunicationConfig,
     pub board: BoardConfig,
     pub storage: Option<Storage>,
@@ -33,6 +37,26 @@ pub struct Hardware {
     pub display: Option<DisplayConfig>,
     pub output: Vec<OutputConfig>,
     pub dependency: DependencyConfig,
+}
+
+impl Hardware {
+    /// Resolve the chip model and chip-specific config for a split board.
+    ///
+    /// If the board defines its own `chip`, that chip is used; otherwise the
+    /// top-level keyboard chip is used.
+    pub fn chip_for_split_board(&self, board_config: &SplitBoardConfig) -> (ChipModel, ChipConfig) {
+        let chip_model = board_config
+            .chip
+            .as_ref()
+            .map(|chip| parse_chip_model(chip).expect("Invalid split board chip"))
+            .unwrap_or_else(|| self.chip.clone());
+        let chip_config = self
+            .chip_configs
+            .get(&chip_model.chip)
+            .cloned()
+            .unwrap_or_default();
+        (chip_model, chip_config)
+    }
 }
 
 impl crate::KeyboardTomlConfig {
@@ -60,6 +84,7 @@ impl crate::KeyboardTomlConfig {
         Ok(Hardware {
             chip,
             chip_config,
+            chip_configs: self.chip.clone().unwrap_or_default(),
             communication,
             board,
             storage,

--- a/rmk-macro/src/codegen/chip/chip_init.rs
+++ b/rmk-macro/src/codegen/chip/chip_init.rs
@@ -2,7 +2,7 @@ use darling::FromMeta;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
 use rmk_config::resolved::Hardware;
-use rmk_config::resolved::hardware::{BoardConfig, ChipModel, ChipSeries, CommunicationConfig};
+use rmk_config::resolved::hardware::{BoardConfig, ChipConfig, ChipModel, ChipSeries, CommunicationConfig};
 use syn::{ItemFn, ItemMod};
 
 use crate::codegen::override_helper::Overwritten;
@@ -15,6 +15,8 @@ pub(crate) fn expand_chip_init(
     hardware: &Hardware,
     peripheral_id: Option<usize>,
     item_mod: &ItemMod,
+    chip: &ChipModel,
+    chip_config: &ChipConfig,
 ) -> TokenStream2 {
     // If there is a function with `#[Overwritten(usb)]`, override the chip initialization
     if let Some((_, items)) = &item_mod.content {
@@ -26,7 +28,7 @@ pub(crate) fn expand_chip_init(
                 {
                     match Overwritten::from_meta(&item_fn.attrs[0].meta) {
                         Ok(Overwritten::ChipConfig) => {
-                            return Some(override_chip_config(&hardware.chip, item_fn));
+                            return Some(override_chip_config(chip, item_fn));
                         }
                         Ok(Overwritten::ChipInit) => {
                             // Override the whole chip initialization
@@ -38,15 +40,19 @@ pub(crate) fn expand_chip_init(
                 }
                 None
             })
-            .unwrap_or(chip_init_default(hardware, peripheral_id))
+            .unwrap_or(chip_init_default(hardware, peripheral_id, chip, chip_config))
     } else {
-        chip_init_default(hardware, peripheral_id)
+        chip_init_default(hardware, peripheral_id, chip, chip_config)
     }
 }
 
 // Default implementations of chip initialization
-pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize>) -> TokenStream2 {
-    let chip = &hardware.chip;
+pub(crate) fn chip_init_default(
+    hardware: &Hardware,
+    peripheral_id: Option<usize>,
+    chip: &ChipModel,
+    chip_config: &ChipConfig,
+) -> TokenStream2 {
     let communication = &hardware.communication;
     let peri_num = hardware.board.get_num_periphreal();
     let set_io_capabilities = if peripheral_id.is_none() {
@@ -64,7 +70,7 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
                 let mut p = ::embassy_stm32::init(config);
         },
         ChipSeries::Nrf52 => {
-            let chip_cfg = &hardware.chip_config;
+            let chip_cfg = chip_config;
             let dcdc_config = if chip.chip == "nrf52840" {
                 let reg0_enabled = chip_cfg.dcdc_reg0.unwrap_or(true);
                 let reg1_enabled = chip_cfg.dcdc_reg1.unwrap_or(true);
@@ -94,7 +100,7 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
             } else {
                 quote! {}
             };
-            let ble_addr = get_ble_addr(hardware, peripheral_id);
+            let ble_addr = get_ble_addr(hardware, chip, peripheral_id);
             // Calculate the size of sdc memory pool.
             // By default it's 6KB, each peripheral increases 2304 bytes
             let sdc_mem_size = if peripheral_id.is_none() {
@@ -155,7 +161,7 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
             }
         }
         ChipSeries::Rp2040 => {
-            let ble_addr = get_ble_addr(hardware, peripheral_id);
+            let ble_addr = get_ble_addr(hardware, chip, peripheral_id);
             if communication.ble_enabled() {
                 quote! {
                     let config = ::embassy_rp::config::Config::default();
@@ -225,7 +231,7 @@ pub(crate) fn chip_init_default(hardware: &Hardware, peripheral_id: Option<usize
             }
         }
         ChipSeries::Esp32 => {
-            let ble_addr = get_ble_addr(hardware, peripheral_id);
+            let ble_addr = get_ble_addr(hardware, chip, peripheral_id);
             quote! {
                 ::esp_println::logger::init_logger_from_env();
                 let p = ::esp_hal::init(::esp_hal::Config::default().with_cpu_clock(::esp_hal::clock::CpuClock::max()));
@@ -275,8 +281,8 @@ fn override_chip_config(chip: &ChipModel, item_fn: &ItemFn) -> TokenStream2 {
     initialization_tokens
 }
 
-fn get_ble_addr(hardware: &Hardware, peripheral_id: Option<usize>) -> TokenStream2 {
-    if hardware.chip.series == ChipSeries::Nrf52 {
+fn get_ble_addr(hardware: &Hardware, chip: &ChipModel, peripheral_id: Option<usize>) -> TokenStream2 {
+    if chip.series == ChipSeries::Nrf52 {
         quote! {
             {
                 let ficr = ::embassy_nrf::pac::FICR;

--- a/rmk-macro/src/codegen/chip/flash.rs
+++ b/rmk-macro/src/codegen/chip/flash.rs
@@ -4,9 +4,9 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use rmk_config::resolved::Hardware;
-use rmk_config::resolved::hardware::ChipSeries;
+use rmk_config::resolved::hardware::{ChipModel, ChipSeries};
 
-pub(crate) fn expand_flash_init(hardware: &Hardware) -> TokenStream2 {
+pub(crate) fn expand_flash_init(hardware: &Hardware, chip: &ChipModel) -> TokenStream2 {
     if hardware.storage.is_none() {
         // This config actually does nothing if storage is disabled
         return quote! {
@@ -28,7 +28,7 @@ pub(crate) fn expand_flash_init(hardware: &Hardware) -> TokenStream2 {
         };
     };
     flash_init.extend(
-    match hardware.chip.series {
+    match chip.series {
             ChipSeries::Stm32 => {
                 quote! {
                     let flash = ::rmk::storage::async_flash_wrapper(::embassy_stm32::flash::Flash::new_blocking(p.FLASH));

--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -219,9 +219,9 @@ fn expand_main(
     // Expand components of main function
     let imports = expand_custom_imports(&item_mod);
     let bind_interrupt = expand_bind_interrupt(hardware, &item_mod);
-    let chip_init = expand_chip_init(hardware, None, &item_mod);
+    let chip_init = expand_chip_init(hardware, None, &item_mod, &hardware.chip, &hardware.chip_config);
     let usb_init = expand_usb_init(hardware, &item_mod);
-    let flash_init = expand_flash_init(hardware);
+    let flash_init = expand_flash_init(hardware, &hardware.chip);
     let behavior_config = expand_behavior_config(behavior);
     let matrix_config = expand_matrix_config(hardware, rmk_features);
     let output_config = expand_output_config(hardware);
@@ -260,7 +260,7 @@ fn expand_main(
         quote! {}
     };
 
-    let (watchdog_init, watchdog_task) = expand_watchdog_init(hardware);
+    let (watchdog_init, watchdog_task) = expand_watchdog_init(&hardware.chip);
 
     let run_rmk = expand_rmk_entry(
         hardware,

--- a/rmk-macro/src/codegen/split/peripheral.rs
+++ b/rmk-macro/src/codegen/split/peripheral.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use rmk_config::resolved::Hardware;
 use rmk_config::resolved::hardware::{
-    BleConfig, BoardConfig, ChipModel, ChipSeries, CommunicationConfig, InputDeviceConfig,
+    BleConfig, BoardConfig, ChipConfig, ChipModel, ChipSeries, CommunicationConfig, InputDeviceConfig,
     MatrixType, SplitBoardConfig, SplitConfig,
 };
 use syn::ItemMod;
@@ -39,17 +39,32 @@ pub(crate) fn parse_split_peripheral_mod(
         panic!("\"split\" feature of RMK should be enabled");
     }
 
-    let toml_config = read_keyboard_toml_config();
-    let hardware = toml_config
+    let hardware = read_keyboard_toml_config()
         .hardware()
         .expect("failed to resolve hardware config");
 
-    let main_function = expand_split_peripheral(id, &hardware, item_mod, &rmk_features);
+    let peripheral_config = match &hardware.board {
+        BoardConfig::Split(split) => split
+            .peripheral
+            .get(id)
+            .expect("Missing peripheral config"),
+        _ => panic!("No `split` field in `keyboard.toml`"),
+    };
+    let (peripheral_chip, peripheral_chip_config) = hardware.chip_for_split_board(peripheral_config);
 
-    let bind_interrupts = expand_bind_interrupt_for_split_peripheral(&hardware.chip, &hardware, id);
+    let main_function = expand_split_peripheral(
+        id,
+        &hardware,
+        &peripheral_chip,
+        &peripheral_chip_config,
+        item_mod,
+        &rmk_features,
+    );
 
-    let chip = &hardware.chip;
-    let main_function_sig = if chip.series == ChipSeries::Esp32 {
+    let bind_interrupts =
+        expand_bind_interrupt_for_split_peripheral(&peripheral_chip, &hardware, id);
+
+    let main_function_sig = if peripheral_chip.series == ChipSeries::Esp32 {
         quote! {
             use esp_alloc as _;
             use esp_backtrace as _;
@@ -241,6 +256,8 @@ fn expand_bind_interrupt_for_split_peripheral(
 fn expand_split_peripheral(
     id: usize,
     hardware: &Hardware,
+    chip: &ChipModel,
+    chip_config: &ChipConfig,
     item_mod: ItemMod,
     rmk_features: &Option<Vec<String>>,
 ) -> TokenStream2 {
@@ -258,10 +275,10 @@ fn expand_split_peripheral(
         .expect("Missing peripheral config");
 
     let imports = expand_custom_imports(&item_mod);
-    let mut chip_init = expand_chip_init(hardware, Some(id), &item_mod);
+    let mut chip_init = expand_chip_init(hardware, Some(id), &item_mod, chip, chip_config);
     if split_config.connection == "ble" {
         // Add storage when using BLE split
-        let flash_init = expand_flash_init(hardware);
+        let flash_init = expand_flash_init(hardware, chip);
         chip_init.extend(quote! {
             #flash_init
             let mut storage = ::rmk::storage::new_storage_for_split_peripheral(flash, storage_config).await;
@@ -274,7 +291,6 @@ fn expand_split_peripheral(
 
     // Matrix config
     let async_matrix = is_feature_enabled(rmk_features, "async_matrix");
-    let chip = &hardware.chip;
     let mut matrix_config = proc_macro2::TokenStream::new();
     let bootmagic = expand_bootmagic_check(&peripheral_config.matrix);
     let debouncer_type = get_debouncer_type(&peripheral_config.matrix);
@@ -334,7 +350,7 @@ fn expand_split_peripheral(
 
     // Get peripheral device and processor configuration
     let (device_initialization, devices, processors) =
-        expand_peripheral_input_device_config(id, hardware);
+        expand_peripheral_input_device_config(id, hardware, chip);
 
     let needs_keymap = peripheral_config
         .input_device
@@ -378,7 +394,7 @@ fn expand_split_peripheral(
         quote! {}
     };
 
-    let (watchdog_init, watchdog_task) = expand_watchdog_init(hardware);
+    let (watchdog_init, watchdog_task) = expand_watchdog_init(chip);
 
     let runnable_import = if !registered_processors.is_empty() || watchdog_task.is_some() {
         quote! { use ::rmk::core_traits::Runnable; }
@@ -510,6 +526,7 @@ fn expand_split_peripheral_entry(
 pub(crate) fn expand_peripheral_input_device_config(
     id: usize,
     hardware: &Hardware,
+    chip: &ChipModel,
 ) -> (TokenStream2, Vec<TokenStream2>, Vec<TokenStream2>) {
     let mut initializations = TokenStream2::new();
     let mut devices = Vec::new();
@@ -523,7 +540,6 @@ pub(crate) fn expand_peripheral_input_device_config(
         _ => None,
     };
     let board = &hardware.board;
-    let chip = &hardware.chip;
 
     // Create peripheral-specific BLE config for battery
     // Only use peripheral's own battery config, do NOT fallback to top-level BLE config

--- a/rmk-macro/src/codegen/watchdog.rs
+++ b/rmk-macro/src/codegen/watchdog.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use rmk_config::resolved::Hardware;
+use rmk_config::resolved::hardware::ChipModel;
 #[cfg(feature = "watchdog")]
 use rmk_config::resolved::hardware::ChipSeries;
 
@@ -12,8 +12,8 @@ use rmk_config::resolved::hardware::ChipSeries;
 ///
 /// Chips without codegen return empty tokens and `None`.
 #[cfg(feature = "watchdog")]
-pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option<TokenStream2>) {
-    let init = match hardware.chip.series {
+pub(crate) fn expand_watchdog_init(chip: &ChipModel) -> (TokenStream2, Option<TokenStream2>) {
+    let init = match chip.series {
         ChipSeries::Rp2040 => quote! {
             let mut watchdog_runner = ::rmk::watchdog::Rp2040Watchdog::default_runner(
                 ::embassy_rp::watchdog::Watchdog::new(p.WATCHDOG),
@@ -49,6 +49,6 @@ pub(crate) fn expand_watchdog_init(hardware: &Hardware) -> (TokenStream2, Option
 
 /// No-op when the `watchdog` feature is disabled; codegen emits nothing.
 #[cfg(not(feature = "watchdog"))]
-pub(crate) fn expand_watchdog_init(_hardware: &Hardware) -> (TokenStream2, Option<TokenStream2>) {
+pub(crate) fn expand_watchdog_init(_chip: &ChipModel) -> (TokenStream2, Option<TokenStream2>) {
     (quote! {}, None)
 }


### PR DESCRIPTION
- Add `chip` option to `SplitBoardConfig` so split peripherals can use a

  different chip than the top-level keyboard.

- Resolve `[chip.<name>]` overrides into `Hardware.chip_configs`.

- Thread explicit `ChipModel`/`ChipConfig` through chip_init, flash_init,

  watchdog, and split peripheral code generation.