### PR TITLE
Add bounded split application messages

### DIFF
--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -110,6 +110,9 @@ pub mod matrix;
 pub mod processor;
 #[cfg(feature = "split")]
 pub mod split;
+// Bounded application-message hook for the split protocol.
+#[cfg(feature = "split")]
+pub mod split_app;
 pub mod state;
 #[cfg(feature = "storage")]
 pub mod storage;

--- a/rmk/src/lib.rs
+++ b/rmk/src/lib.rs
@@ -110,7 +110,6 @@ pub mod matrix;
 pub mod processor;
 #[cfg(feature = "split")]
 pub mod split;
-// Bounded application-message hook for the split protocol.
 #[cfg(feature = "split")]
 pub mod split_app;
 pub mod state;

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -210,6 +210,24 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
         #[cfg(feature = "display")]
         let mut sleep_sub = crate::event::SleepStateEvent::subscriber();
 
+        // Expose the split-link state to the application. This
+        // manager runs exactly while the peripheral session is up; the
+        // `false → true` edge is the application's resync trigger.
+        //
+        // The link-down edge MUST be sent from a drop guard: on connection
+        // loss the outer `select3` in `split/ble/central.rs` resolves via its
+        // connection-monitor arm and this future is *cancelled*, so any
+        // `send(false)` written on an error path here would never run.
+        struct LinkDownGuard;
+        impl Drop for LinkDownGuard {
+            fn drop(&mut self) {
+                crate::split_app::SPLIT_APP_LINK.sender().send(false);
+            }
+        }
+        let _link_guard = LinkDownGuard;
+        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
+        app_link.send(true);
+
         // Send the current state once on startup so the peripheral matches us
         // even when no transition has happened since the central booted.
         if self
@@ -219,7 +237,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             .await
             .is_err()
         {
-            return;
+            return; // guard sends the link-down edge
         }
 
         #[cfg(feature = "dfu_split")]
@@ -251,6 +269,10 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                     with_feature("display"): e = wpm_sub.next_event().fuse() => SplitMessage::Wpm(e.0),
                     with_feature("display"): e = modifier_sub.next_event().fuse() => SplitMessage::Modifier(e.modifier.into_bits()),
                     with_feature("display"): e = sleep_sub.next_event().fuse() => SplitMessage::SleepState(e.0),
+                    // Application messages, deliberately the
+                    // last (lowest-priority) outgoing arm; the read arm of the
+                    // outer select still beats all outgoing traffic.
+                    m = crate::split_app::SPLIT_APP_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
 
@@ -280,7 +302,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                 #[cfg(not(feature = "dfu_split"))]
                 Either::Second(msg) => {
                     if self.send(&msg).await.is_err() {
-                        return;
+                        return; // guard sends the link-down edge
                     }
                 }
             }
@@ -309,6 +331,14 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             },
             // Non-key events are drop-on-full to keep the split read loop responsive.
             SplitMessage::Pointing(e) => publish_event(e),
+            // Forward peripheral → central application
+            // payloads into the (symmetric) inbox; drop-on-full so a slow
+            // consumer can never stall the split read loop.
+            SplitMessage::Application(data) => {
+                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                    warn!("split app message dropped (inbox full)");
+                }
+            }
             #[cfg(feature = "_ble")]
             SplitMessage::BatteryStatus(state) => set_peripheral_battery(self.id, state.0),
             #[cfg(feature = "dfu_split")]

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -210,23 +210,11 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
         #[cfg(feature = "display")]
         let mut sleep_sub = crate::event::SleepStateEvent::subscriber();
 
-        // Expose the split-link state to the application. This
-        // manager runs exactly while the peripheral session is up; the
-        // `false → true` edge is the application's resync trigger.
-        //
-        // The link-down edge MUST be sent from a drop guard: on connection
-        // loss the outer `select3` in `split/ble/central.rs` resolves via its
-        // connection-monitor arm and this future is *cancelled*, so any
-        // `send(false)` written on an error path here would never run.
-        struct LinkDownGuard;
-        impl Drop for LinkDownGuard {
-            fn drop(&mut self) {
-                crate::split_app::SPLIT_APP_LINK.sender().send(false);
-            }
-        }
-        let _link_guard = LinkDownGuard;
-        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
-        app_link.send(true);
+        // This manager runs exactly while the peripheral session is up. On
+        // connection loss the `select3` in `split/ble/central.rs` cancels this
+        // future, so the guard's `Drop` is what sends the link-down edge.
+        let mut app_link = crate::split_app::LinkGuard::new();
+        app_link.mark_up();
 
         // Send the current state once on startup so the peripheral matches us
         // even when no transition has happened since the central booted.
@@ -237,7 +225,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             .await
             .is_err()
         {
-            return; // guard sends the link-down edge
+            return;
         }
 
         #[cfg(feature = "dfu_split")]
@@ -269,9 +257,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                     with_feature("display"): e = wpm_sub.next_event().fuse() => SplitMessage::Wpm(e.0),
                     with_feature("display"): e = modifier_sub.next_event().fuse() => SplitMessage::Modifier(e.modifier.into_bits()),
                     with_feature("display"): e = sleep_sub.next_event().fuse() => SplitMessage::SleepState(e.0),
-                    // Application messages, deliberately the
-                    // last (lowest-priority) outgoing arm; the read arm of the
-                    // outer select still beats all outgoing traffic.
+                    // Deliberately the last (lowest-priority) outgoing arm.
                     m = crate::split_app::SPLIT_APP_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
@@ -302,7 +288,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                 #[cfg(not(feature = "dfu_split"))]
                 Either::Second(msg) => {
                     if self.send(&msg).await.is_err() {
-                        return; // guard sends the link-down edge
+                        return;
                     }
                 }
             }
@@ -331,14 +317,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             },
             // Non-key events are drop-on-full to keep the split read loop responsive.
             SplitMessage::Pointing(e) => publish_event(e),
-            // Forward peripheral → central application
-            // payloads into the (symmetric) inbox; drop-on-full so a slow
-            // consumer can never stall the split read loop.
-            SplitMessage::Application(data) => {
-                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
-                    warn!("split app message dropped (inbox full)");
-                }
-            }
+            SplitMessage::Application(data) => crate::split_app::deliver_received(data),
             #[cfg(feature = "_ble")]
             SplitMessage::BatteryStatus(state) => set_peripheral_battery(self.id, state.0),
             #[cfg(feature = "dfu_split")]

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -209,6 +209,24 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
         let mut modifier_sub = crate::event::ModifierEvent::subscriber();
         let mut sleep_sub = crate::event::SleepStateEvent::subscriber();
 
+        // Expose the split-link state to the application. This
+        // manager runs exactly while the peripheral session is up; the
+        // `false → true` edge is the application's resync trigger.
+        //
+        // The link-down edge MUST be sent from a drop guard: on connection
+        // loss the outer `select3` in `split/ble/central.rs` resolves via its
+        // connection-monitor arm and this future is *cancelled*, so any
+        // `send(false)` written on an error path here would never run.
+        struct LinkDownGuard;
+        impl Drop for LinkDownGuard {
+            fn drop(&mut self) {
+                crate::split_app::SPLIT_APP_LINK.sender().send(false);
+            }
+        }
+        let _link_guard = LinkDownGuard;
+        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
+        app_link.send(true);
+
         // Send the current state once on startup so the peripheral matches us
         // even when no transition has happened since the central booted.
         if self
@@ -218,7 +236,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             .await
             .is_err()
         {
-            return;
+            return; // guard sends the link-down edge
         }
 
         #[cfg(feature = "dfu_split")]
@@ -250,6 +268,10 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                     e = sleep_sub.next_event().fuse() => SplitMessage::SleepState(e.0),
                     with_feature("display"): e = wpm_sub.next_event().fuse() => SplitMessage::Wpm(e.0),
                     with_feature("display"): e = modifier_sub.next_event().fuse() => SplitMessage::Modifier(e.modifier.into_bits()),
+                    // Application messages, deliberately the
+                    // last (lowest-priority) outgoing arm; the read arm of the
+                    // outer select still beats all outgoing traffic.
+                    m = crate::split_app::SPLIT_APP_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
 
@@ -279,7 +301,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                 #[cfg(not(feature = "dfu_split"))]
                 Either::Second(msg) => {
                     if self.send(&msg).await.is_err() {
-                        return;
+                        return; // guard sends the link-down edge
                     }
                 }
             }
@@ -308,6 +330,14 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             },
             // Non-key events are drop-on-full to keep the split read loop responsive.
             SplitMessage::Pointing(e) => publish_event(e),
+            // Forward peripheral → central application
+            // payloads into the (symmetric) inbox; drop-on-full so a slow
+            // consumer can never stall the split read loop.
+            SplitMessage::Application(data) => {
+                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                    warn!("split app message dropped (inbox full)");
+                }
+            }
             #[cfg(feature = "_ble")]
             SplitMessage::BatteryStatus(state) => set_peripheral_battery(self.id, state.0),
             #[cfg(feature = "dfu_split")]

--- a/rmk/src/split/driver.rs
+++ b/rmk/src/split/driver.rs
@@ -209,23 +209,11 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
         let mut modifier_sub = crate::event::ModifierEvent::subscriber();
         let mut sleep_sub = crate::event::SleepStateEvent::subscriber();
 
-        // Expose the split-link state to the application. This
-        // manager runs exactly while the peripheral session is up; the
-        // `false → true` edge is the application's resync trigger.
-        //
-        // The link-down edge MUST be sent from a drop guard: on connection
-        // loss the outer `select3` in `split/ble/central.rs` resolves via its
-        // connection-monitor arm and this future is *cancelled*, so any
-        // `send(false)` written on an error path here would never run.
-        struct LinkDownGuard;
-        impl Drop for LinkDownGuard {
-            fn drop(&mut self) {
-                crate::split_app::SPLIT_APP_LINK.sender().send(false);
-            }
-        }
-        let _link_guard = LinkDownGuard;
-        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
-        app_link.send(true);
+        // This manager runs exactly while the peripheral session is up. On
+        // connection loss the `select3` in `split/ble/central.rs` cancels this
+        // future, so the guard's `Drop` is what sends the link-down edge.
+        let mut app_link = crate::split_app::LinkGuard::new();
+        app_link.mark_up();
 
         // Send the current state once on startup so the peripheral matches us
         // even when no transition has happened since the central booted.
@@ -236,7 +224,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             .await
             .is_err()
         {
-            return; // guard sends the link-down edge
+            return;
         }
 
         #[cfg(feature = "dfu_split")]
@@ -268,9 +256,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                     e = sleep_sub.next_event().fuse() => SplitMessage::SleepState(e.0),
                     with_feature("display"): e = wpm_sub.next_event().fuse() => SplitMessage::Wpm(e.0),
                     with_feature("display"): e = modifier_sub.next_event().fuse() => SplitMessage::Modifier(e.modifier.into_bits()),
-                    // Application messages, deliberately the
-                    // last (lowest-priority) outgoing arm; the read arm of the
-                    // outer select still beats all outgoing traffic.
+                    // Deliberately the last (lowest-priority) outgoing arm.
                     m = crate::split_app::SPLIT_APP_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
@@ -301,7 +287,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
                 #[cfg(not(feature = "dfu_split"))]
                 Either::Second(msg) => {
                     if self.send(&msg).await.is_err() {
-                        return; // guard sends the link-down edge
+                        return;
                     }
                 }
             }
@@ -330,14 +316,7 @@ impl<T: SplitReader + SplitWriter> PeripheralManager<T> {
             },
             // Non-key events are drop-on-full to keep the split read loop responsive.
             SplitMessage::Pointing(e) => publish_event(e),
-            // Forward peripheral → central application
-            // payloads into the (symmetric) inbox; drop-on-full so a slow
-            // consumer can never stall the split read loop.
-            SplitMessage::Application(data) => {
-                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
-                    warn!("split app message dropped (inbox full)");
-                }
-            }
+            SplitMessage::Application(data) => crate::split_app::deliver_received(data),
             #[cfg(feature = "_ble")]
             SplitMessage::BatteryStatus(state) => set_peripheral_battery(self.id, state.0),
             #[cfg(feature = "dfu_split")]

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -102,6 +102,12 @@ pub(crate) enum SplitMessage {
     /// Peripheral → Central: confirm mark_updated succeeded, about to reset.
     #[cfg(feature = "dfu_split")]
     FirmwareUpdateConfirm,
+
+    /// opaque bounded application payload, central →
+    /// peripheral (see `crate::split_app`). Kept as the LAST variant so
+    /// the postcard discriminants of all existing messages stay stable across
+    /// halves flashed at different revisions.
+    Application(crate::split_app::SplitAppData),
 }
 
 // -----------------------------------------------------------------------

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -103,10 +103,9 @@ pub(crate) enum SplitMessage {
     #[cfg(feature = "dfu_split")]
     FirmwareUpdateConfirm,
 
-    /// opaque bounded application payload, central →
-    /// peripheral (see `crate::split_app`). Kept as the LAST variant so
-    /// the postcard discriminants of all existing messages stay stable across
-    /// halves flashed at different revisions.
+    /// Opaque application payload, either direction (see `crate::split_app`).
+    /// Kept as the last variant so the postcard discriminants of existing
+    /// messages stay stable across halves flashed at different revisions.
     Application(crate::split_app::SplitAppData),
 }
 

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -101,6 +101,12 @@ pub(crate) enum SplitMessage {
     /// Peripheral → Central: confirm mark_updated succeeded, about to reset.
     #[cfg(feature = "dfu_split")]
     FirmwareUpdateConfirm,
+
+    /// opaque bounded application payload, central →
+    /// peripheral (see `crate::split_app`). Kept as the LAST variant so
+    /// the postcard discriminants of all existing messages stay stable across
+    /// halves flashed at different revisions.
+    Application(crate::split_app::SplitAppData),
 }
 
 // -----------------------------------------------------------------------

--- a/rmk/src/split/mod.rs
+++ b/rmk/src/split/mod.rs
@@ -102,10 +102,9 @@ pub(crate) enum SplitMessage {
     #[cfg(feature = "dfu_split")]
     FirmwareUpdateConfirm,
 
-    /// opaque bounded application payload, central →
-    /// peripheral (see `crate::split_app`). Kept as the LAST variant so
-    /// the postcard discriminants of all existing messages stay stable across
-    /// halves flashed at different revisions.
+    /// Opaque application payload, either direction (see `crate::split_app`).
+    /// Kept as the last variant so the postcard discriminants of existing
+    /// messages stay stable across halves flashed at different revisions.
     Application(crate::split_app::SplitAppData),
 }
 

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -24,27 +24,25 @@ use crate::event::{ModifierEvent, SleepStateEvent, WpmUpdateEvent};
 use crate::split::serial::SerialSplitDriver;
 use crate::state::update_status;
 
-/// Run the split peripheral service.
+/// Run the split peripheral service. On BLE builds this owns the peripheral's
+/// whole BLE stack, sized to its single link (the central) — nothing else
+/// uses it.
 ///
 /// # Arguments
 ///
 /// * `id` - (optional) The id of the peripheral
-/// * `stack` - (optional) The TrouBLE stack
+/// * `controller` - (optional) The BLE controller
+/// * `address` - (optional) The BLE address of this peripheral
 /// * `serial` - (optional) serial port used to send peripheral split message. This argument is enabled only for serial split now
-/// * `storage` - (optional) The storage to save the central address
-#[allow(clippy::extra_unused_lifetimes)]
 pub async fn run_rmk_split_peripheral<
-    'b,
-    's,
     #[cfg(feature = "_ble")] C: Controller + ControllerCmdAsync<LeSetPhy>,
     #[cfg(not(feature = "_ble"))] S: Write + Read,
 >(
     #[cfg(feature = "_ble")] id: usize,
-    #[cfg(feature = "_ble")] stack: &'b Stack<'s, C, DefaultPacketPool>,
+    #[cfg(feature = "_ble")] controller: C,
+    #[cfg(feature = "_ble")] address: [u8; 6],
     #[cfg(not(feature = "_ble"))] serial: S,
-) where
-    's: 'b,
-{
+) {
     #[cfg(not(feature = "_ble"))]
     {
         let mut peripheral = SplitPeripheral::new(SerialSplitDriver::new(serial));
@@ -54,7 +52,14 @@ pub async fn run_rmk_split_peripheral<
     }
 
     #[cfg(feature = "_ble")]
-    crate::split::ble::peripheral::initialize_nrf_ble_split_peripheral_and_run(id, stack).await;
+    {
+        // Exactly one link — the central.
+        let mut resources: HostResources<DefaultPacketPool, 1, 4> = HostResources::new();
+        let stack = trouble_host::new(controller, &mut resources)
+            .set_random_address(Address::random(address))
+            .build();
+        crate::split::ble::peripheral::initialize_nrf_ble_split_peripheral_and_run(id, &stack).await;
+    }
 }
 
 /// The split peripheral instance.

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -83,6 +83,40 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
     /// The peripheral uses the general matrix, does scanning and sends key events through `SplitWriter`.
     /// It also receives split messages from the central through `SplitReader`.
     pub(crate) async fn run(&mut self) {
+        // Expose the split-link state to the application.
+        // `run` executes exactly while a central session is up (for BLE it is
+        // invoked per connection and returns on disconnect).
+        //
+        // As on the central side (split/driver.rs), the link-down edge MUST
+        // come from a drop guard: this future can be cancelled from outside
+        // when the session dies, so no in-line `send(false)` is guaranteed to
+        // run. Without the false edge, reconnects look like true->true and
+        // link-up-triggered behavior (e.g. the version announcement) never
+        // re-arms.
+        //
+        // The link-UP edge is deliberately NOT sent here at session start:
+        // for BLE the connection is up, but the central has not yet
+        // subscribed to the peripheral's notify characteristic (CCCD write),
+        // and trouble-host silently drops notifications to an unsubscribed
+        // peer — anything the application sent in that window would vanish.
+        // Instead, link-up is declared on the FIRST message received from
+        // the central: the central's `PeripheralManager` sends its
+        // `ConnectionStatus` snapshot immediately after subscribing, and ATT
+        // bearer ordering guarantees the CCCD write was processed before
+        // that message, so peripheral → central traffic is deliverable from
+        // this point on. (Serial split has no subscription step and reaches
+        // the same first message; the edge is simply "the session is
+        // bidirectionally live".)
+        struct LinkDownGuard;
+        impl Drop for LinkDownGuard {
+            fn drop(&mut self) {
+                crate::split_app::SPLIT_APP_LINK.sender().send(false);
+            }
+        }
+        let _link_guard = LinkDownGuard;
+        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
+        let mut link_up_sent = false;
+
         // Proactively announce our firmware hash so the central can detect
         // us even when it booted first and already gave up waiting for a query response.
         #[cfg(feature = "dfu_split")]
@@ -113,135 +147,158 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                     },
                     e = pointing_sub.next_message_pure().fuse() => SplitMessage::Pointing(e),
                     with_feature("_ble"): e = battery_sub.next_event().fuse() => SplitMessage::BatteryStatus(e),
+                    // Peripheral → central application
+                    // messages, deliberately the last (lowest-priority)
+                    // outgoing arm behind key events.
+                    m = crate::split_app::SPLIT_APP_PERIPH_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
 
             match select(self.split_driver.read(), read_message_to_send).await {
                 Either::First(m) => match m {
                     // Process split messages from the central
-                    Ok(split_message) => match split_message {
-                        SplitMessage::ConnectionStatus(status) => {
-                            trace!("Received central connection status: {:?}", status);
-                            update_status(|c| *c = status);
-                            // The central sends this only after subscribing to split notifications.
-                            #[cfg(feature = "_ble")]
-                            self.split_driver
-                                .write(&SplitMessage::BatteryStatus(
-                                    crate::input_device::battery::current_battery_status().into(),
-                                ))
-                                .await
-                                .ok();
+                    Ok(split_message) => {
+                        // First traffic from the central ⇒ the
+                        // session is bidirectionally live (see the LinkDownGuard
+                        // comment above for why link-up is not sent at start).
+                        if !link_up_sent {
+                            app_link.send(true);
+                            link_up_sent = true;
                         }
-                        #[cfg(all(feature = "_ble", feature = "storage"))]
-                        SplitMessage::ClearPeer => {
-                            // Clear the peer address
-                            FLASH_CHANNEL
-                                .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
-                                    0, false, [0; 6],
-                                )))
-                                .await;
-                        }
-                        SplitMessage::KeyboardIndicator(indicator) => {
-                            // Publish KeyboardIndicator event
-                            publish_event(LedIndicatorEvent::new(
-                                rmk_types::led_indicator::LedIndicator::from_bits(indicator),
-                            ));
-                        }
-                        SplitMessage::Layer(layer) => {
-                            // Publish Layer event
-                            publish_event(LayerChangeEvent::new(layer));
-                        }
-                        #[cfg(feature = "display")]
-                        SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
-                        #[cfg(feature = "display")]
-                        SplitMessage::Modifier(bits) => {
-                            publish_event(ModifierEvent {
-                                modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
-                            });
-                        }
-                        #[cfg(feature = "display")]
-                        SplitMessage::SleepState(sleeping) => {
-                            publish_event(SleepStateEvent::new(sleeping));
-                        }
-                        // --- dfu_split: firmware update handlers ---
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareHashQuery => {
-                            let hash = crate::dfu::read_embedded_firmware_hash();
-                            info!("dfu_split: hash query, responding with {:#x}", hash);
-                            self.split_driver
-                                .write(&SplitMessage::FirmwareHashResponse(hash))
-                                .await
-                                .ok();
-                        }
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareChunk { offset, len, data } => {
-                            if self.dfu_handler.is_none() {
-                                self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                        match split_message {
+                            SplitMessage::ConnectionStatus(status) => {
+                                trace!("Received central connection status: {:?}", status);
+                                update_status(|c| *c = status);
+                                // The central sends this only after subscribing to split notifications.
+                                #[cfg(feature = "_ble")]
+                                self.split_driver
+                                    .write(&SplitMessage::BatteryStatus(
+                                        crate::input_device::battery::current_battery_status().into(),
+                                    ))
+                                    .await
+                                    .ok();
+                            }
+                            #[cfg(all(feature = "_ble", feature = "storage"))]
+                            SplitMessage::ClearPeer => {
+                                // Clear the peer address
+                                FLASH_CHANNEL
+                                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
+                                        0, false, [0; 6],
+                                    )))
+                                    .await;
+                            }
+                            SplitMessage::KeyboardIndicator(indicator) => {
+                                // Publish KeyboardIndicator event
+                                publish_event(LedIndicatorEvent::new(
+                                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
+                                ));
+                            }
+                            SplitMessage::Layer(layer) => {
+                                // Publish Layer event
+                                publish_event(LayerChangeEvent::new(layer));
+                            }
+                            #[cfg(feature = "display")]
+                            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
+                            #[cfg(feature = "display")]
+                            SplitMessage::Modifier(bits) => {
+                                publish_event(ModifierEvent {
+                                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
+                                });
+                            }
+                            #[cfg(feature = "display")]
+                            SplitMessage::SleepState(sleeping) => {
+                                publish_event(SleepStateEvent::new(sleeping));
+                            }
+                            // --- dfu_split: firmware update handlers ---
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareHashQuery => {
+                                let hash = crate::dfu::read_embedded_firmware_hash();
+                                info!("dfu_split: hash query, responding with {:#x}", hash);
+                                self.split_driver
+                                    .write(&SplitMessage::FirmwareHashResponse(hash))
+                                    .await
+                                    .ok();
+                            }
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareChunk { offset, len, data } => {
                                 if self.dfu_handler.is_none() {
-                                    error!("dfu_split: FlashManager not initialized, skipping chunk");
-                                    continue;
-                                }
-                            }
-                            let handler = self.dfu_handler.as_mut().unwrap();
-                            let actual_len = len as usize;
-                            let chunk_data = &data.0[..actual_len];
-                            match handler.write_chunk(offset as u32, chunk_data) {
-                                Ok(()) => {
-                                    debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
-                                    let ack = SplitMessage::FirmwareChunkAck {
-                                        offset,
-                                        crc: crate::crc32::crc32(chunk_data),
-                                    };
-                                    self.split_driver.write(&ack).await.ok();
-                                }
-                                Err(()) => error!("dfu_split: write error at offset {}", offset),
-                            }
-                        }
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareUpdateComplete => {
-                            if let Some(ref mut handler) = self.dfu_handler {
-                                let dfu_crc = handler.compute_dfu_crc();
-                                info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
-                                let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
-                                self.split_driver.write(&crc_msg).await.ok();
-                                info!("dfu_split: CRC report sent");
-
-                                let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
-                                let ok = loop {
-                                    match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await {
-                                        Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
-                                            info!("dfu_split: central confirmed CRC, resetting");
-                                            break true;
-                                        }
-                                        Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
-                                            warn!("dfu_split: central rejected CRC, stopping update");
-                                            break false;
-                                        }
-                                        Either::First(Ok(_)) => {}
-                                        Either::First(Err(e)) => {
-                                            error!("read error: {:?}", e);
-                                            break false;
-                                        }
-                                        Either::Second(_) => {
-                                            error!("timeout");
-                                            break false;
-                                        }
+                                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                                    if self.dfu_handler.is_none() {
+                                        error!("dfu_split: FlashManager not initialized, skipping chunk");
+                                        continue;
                                     }
-                                };
-
-                                if ok {
-                                    self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
-                                    embassy_time::Timer::after_millis(50).await;
-                                    handler.mark_updated_and_reset().ok();
-                                } else {
-                                    self.dfu_handler = None;
                                 }
-                            } else {
-                                error!("dfu_split: no active DFU session");
+                                let handler = self.dfu_handler.as_mut().unwrap();
+                                let actual_len = len as usize;
+                                let chunk_data = &data.0[..actual_len];
+                                match handler.write_chunk(offset as u32, chunk_data) {
+                                    Ok(()) => {
+                                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
+                                        let ack = SplitMessage::FirmwareChunkAck {
+                                            offset,
+                                            crc: crate::crc32::crc32(chunk_data),
+                                        };
+                                        self.split_driver.write(&ack).await.ok();
+                                    }
+                                    Err(()) => error!("dfu_split: write error at offset {}", offset),
+                                }
                             }
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareUpdateComplete => {
+                                if let Some(ref mut handler) = self.dfu_handler {
+                                    let dfu_crc = handler.compute_dfu_crc();
+                                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
+                                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
+                                    self.split_driver.write(&crc_msg).await.ok();
+                                    info!("dfu_split: CRC report sent");
+
+                                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
+                                    let ok = loop {
+                                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await
+                                        {
+                                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
+                                                info!("dfu_split: central confirmed CRC, resetting");
+                                                break true;
+                                            }
+                                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
+                                                warn!("dfu_split: central rejected CRC, stopping update");
+                                                break false;
+                                            }
+                                            Either::First(Ok(_)) => {}
+                                            Either::First(Err(e)) => {
+                                                error!("read error: {:?}", e);
+                                                break false;
+                                            }
+                                            Either::Second(_) => {
+                                                error!("timeout");
+                                                break false;
+                                            }
+                                        }
+                                    };
+
+                                    if ok {
+                                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
+                                        embassy_time::Timer::after_millis(50).await;
+                                        handler.mark_updated_and_reset().ok();
+                                    } else {
+                                        self.dfu_handler = None;
+                                    }
+                                } else {
+                                    error!("dfu_split: no active DFU session");
+                                }
+                            }
+                            // Forward application payloads;
+                            // drop-on-full so a slow consumer can never stall the
+                            // split read loop (the application resyncs on
+                            // reconnect and must tolerate loss).
+                            SplitMessage::Application(data) => {
+                                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                                    warn!("split app message dropped (inbox full)");
+                                }
+                            }
+                            _ => (),
                         }
-                        _ => (),
-                    },
+                    }
                     Err(e) => {
                         error!("Split message read error: {:?}", e);
                         if let crate::split::driver::SplitDriverError::Disconnected = e {
@@ -255,5 +312,8 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 }
             }
         }
+
+        // The loop only exits on disconnect.
+        app_link.send(false);
     }
 }

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -24,25 +24,27 @@ use crate::event::{ModifierEvent, SleepStateEvent, WpmUpdateEvent};
 use crate::split::serial::SerialSplitDriver;
 use crate::state::update_status;
 
-/// Run the split peripheral service. On BLE builds this owns the peripheral's
-/// whole BLE stack, sized to its single link (the central) — nothing else
-/// uses it.
+/// Run the split peripheral service.
 ///
 /// # Arguments
 ///
 /// * `id` - (optional) The id of the peripheral
-/// * `controller` - (optional) The BLE controller
-/// * `address` - (optional) The BLE address of this peripheral
+/// * `stack` - (optional) The TrouBLE stack
 /// * `serial` - (optional) serial port used to send peripheral split message. This argument is enabled only for serial split now
+/// * `storage` - (optional) The storage to save the central address
+#[allow(clippy::extra_unused_lifetimes)]
 pub async fn run_rmk_split_peripheral<
+    'b,
+    's,
     #[cfg(feature = "_ble")] C: Controller + ControllerCmdAsync<LeSetPhy>,
     #[cfg(not(feature = "_ble"))] S: Write + Read,
 >(
     #[cfg(feature = "_ble")] id: usize,
-    #[cfg(feature = "_ble")] controller: C,
-    #[cfg(feature = "_ble")] address: [u8; 6],
+    #[cfg(feature = "_ble")] stack: &'b Stack<'s, C, DefaultPacketPool>,
     #[cfg(not(feature = "_ble"))] serial: S,
-) {
+) where
+    's: 'b,
+{
     #[cfg(not(feature = "_ble"))]
     {
         let mut peripheral = SplitPeripheral::new(SerialSplitDriver::new(serial));
@@ -52,14 +54,7 @@ pub async fn run_rmk_split_peripheral<
     }
 
     #[cfg(feature = "_ble")]
-    {
-        // Exactly one link — the central.
-        let mut resources: HostResources<DefaultPacketPool, 1, 4> = HostResources::new();
-        let stack = trouble_host::new(controller, &mut resources)
-            .set_random_address(Address::random(address))
-            .build();
-        crate::split::ble::peripheral::initialize_nrf_ble_split_peripheral_and_run(id, &stack).await;
-    }
+    crate::split::ble::peripheral::initialize_nrf_ble_split_peripheral_and_run(id, stack).await;
 }
 
 /// The split peripheral instance.
@@ -83,39 +78,14 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
     /// The peripheral uses the general matrix, does scanning and sends key events through `SplitWriter`.
     /// It also receives split messages from the central through `SplitReader`.
     pub(crate) async fn run(&mut self) {
-        // Expose the split-link state to the application.
-        // `run` executes exactly while a central session is up (for BLE it is
-        // invoked per connection and returns on disconnect).
-        //
-        // As on the central side (split/driver.rs), the link-down edge MUST
-        // come from a drop guard: this future can be cancelled from outside
-        // when the session dies, so no in-line `send(false)` is guaranteed to
-        // run. Without the false edge, reconnects look like true->true and
-        // link-up-triggered behavior (e.g. the version announcement) never
-        // re-arms.
-        //
-        // The link-UP edge is deliberately NOT sent here at session start:
-        // for BLE the connection is up, but the central has not yet
-        // subscribed to the peripheral's notify characteristic (CCCD write),
-        // and trouble-host silently drops notifications to an unsubscribed
-        // peer — anything the application sent in that window would vanish.
-        // Instead, link-up is declared on the FIRST message received from
-        // the central: the central's `PeripheralManager` sends its
-        // `ConnectionStatus` snapshot immediately after subscribing, and ATT
-        // bearer ordering guarantees the CCCD write was processed before
-        // that message, so peripheral → central traffic is deliverable from
-        // this point on. (Serial split has no subscription step and reaches
-        // the same first message; the edge is simply "the session is
-        // bidirectionally live".)
-        struct LinkDownGuard;
-        impl Drop for LinkDownGuard {
-            fn drop(&mut self) {
-                crate::split_app::SPLIT_APP_LINK.sender().send(false);
-            }
-        }
-        let _link_guard = LinkDownGuard;
-        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
-        let mut link_up_sent = false;
+        // `run` executes exactly while a central session is up; the guard's
+        // `Drop` sends the link-down edge even when this future is cancelled
+        // from outside. Link-up waits for the first message from the central:
+        // a bare BLE connection is not enough, since trouble-host silently
+        // drops notifications until the central subscribes (CCCD write), and
+        // the central's `ConnectionStatus` snapshot arrives right after it
+        // subscribes — so first message ⇒ bidirectionally live.
+        let mut app_link = crate::split_app::LinkGuard::new();
 
         // Proactively announce our firmware hash so the central can detect
         // us even when it booted first and already gave up waiting for a query response.
@@ -147,9 +117,7 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                     },
                     e = pointing_sub.next_message_pure().fuse() => SplitMessage::Pointing(e),
                     with_feature("_ble"): e = battery_sub.next_event().fuse() => SplitMessage::BatteryStatus(e),
-                    // Peripheral → central application
-                    // messages, deliberately the last (lowest-priority)
-                    // outgoing arm behind key events.
+                    // Deliberately the last (lowest-priority) outgoing arm, behind key events.
                     m = crate::split_app::SPLIT_APP_PERIPH_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
@@ -158,147 +126,10 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 Either::First(m) => match m {
                     // Process split messages from the central
                     Ok(split_message) => {
-                        // First traffic from the central ⇒ the
-                        // session is bidirectionally live (see the LinkDownGuard
-                        // comment above for why link-up is not sent at start).
-                        if !link_up_sent {
-                            app_link.send(true);
-                            link_up_sent = true;
-                        }
-                        match split_message {
-                            SplitMessage::ConnectionStatus(status) => {
-                                trace!("Received central connection status: {:?}", status);
-                                update_status(|c| *c = status);
-                                // The central sends this only after subscribing to split notifications.
-                                #[cfg(feature = "_ble")]
-                                self.split_driver
-                                    .write(&SplitMessage::BatteryStatus(
-                                        crate::input_device::battery::current_battery_status().into(),
-                                    ))
-                                    .await
-                                    .ok();
-                            }
-                            #[cfg(all(feature = "_ble", feature = "storage"))]
-                            SplitMessage::ClearPeer => {
-                                // Clear the peer address
-                                FLASH_CHANNEL
-                                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
-                                        0, false, [0; 6],
-                                    )))
-                                    .await;
-                            }
-                            SplitMessage::KeyboardIndicator(indicator) => {
-                                // Publish KeyboardIndicator event
-                                publish_event(LedIndicatorEvent::new(
-                                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
-                                ));
-                            }
-                            SplitMessage::Layer(layer) => {
-                                // Publish Layer event
-                                publish_event(LayerChangeEvent::new(layer));
-                            }
-                            #[cfg(feature = "display")]
-                            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
-                            #[cfg(feature = "display")]
-                            SplitMessage::Modifier(bits) => {
-                                publish_event(ModifierEvent {
-                                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
-                                });
-                            }
-                            #[cfg(feature = "display")]
-                            SplitMessage::SleepState(sleeping) => {
-                                publish_event(SleepStateEvent::new(sleeping));
-                            }
-                            // --- dfu_split: firmware update handlers ---
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareHashQuery => {
-                                let hash = crate::dfu::read_embedded_firmware_hash();
-                                info!("dfu_split: hash query, responding with {:#x}", hash);
-                                self.split_driver
-                                    .write(&SplitMessage::FirmwareHashResponse(hash))
-                                    .await
-                                    .ok();
-                            }
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareChunk { offset, len, data } => {
-                                if self.dfu_handler.is_none() {
-                                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
-                                    if self.dfu_handler.is_none() {
-                                        error!("dfu_split: FlashManager not initialized, skipping chunk");
-                                        continue;
-                                    }
-                                }
-                                let handler = self.dfu_handler.as_mut().unwrap();
-                                let actual_len = len as usize;
-                                let chunk_data = &data.0[..actual_len];
-                                match handler.write_chunk(offset as u32, chunk_data) {
-                                    Ok(()) => {
-                                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
-                                        let ack = SplitMessage::FirmwareChunkAck {
-                                            offset,
-                                            crc: crate::crc32::crc32(chunk_data),
-                                        };
-                                        self.split_driver.write(&ack).await.ok();
-                                    }
-                                    Err(()) => error!("dfu_split: write error at offset {}", offset),
-                                }
-                            }
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareUpdateComplete => {
-                                if let Some(ref mut handler) = self.dfu_handler {
-                                    let dfu_crc = handler.compute_dfu_crc();
-                                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
-                                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
-                                    self.split_driver.write(&crc_msg).await.ok();
-                                    info!("dfu_split: CRC report sent");
-
-                                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
-                                    let ok = loop {
-                                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await
-                                        {
-                                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
-                                                info!("dfu_split: central confirmed CRC, resetting");
-                                                break true;
-                                            }
-                                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
-                                                warn!("dfu_split: central rejected CRC, stopping update");
-                                                break false;
-                                            }
-                                            Either::First(Ok(_)) => {}
-                                            Either::First(Err(e)) => {
-                                                error!("read error: {:?}", e);
-                                                break false;
-                                            }
-                                            Either::Second(_) => {
-                                                error!("timeout");
-                                                break false;
-                                            }
-                                        }
-                                    };
-
-                                    if ok {
-                                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
-                                        embassy_time::Timer::after_millis(50).await;
-                                        handler.mark_updated_and_reset().ok();
-                                    } else {
-                                        self.dfu_handler = None;
-                                    }
-                                } else {
-                                    error!("dfu_split: no active DFU session");
-                                }
-                            }
-                            // Forward application payloads;
-                            // drop-on-full so a slow consumer can never stall the
-                            // split read loop (the application resyncs on
-                            // reconnect and must tolerate loss).
-                            SplitMessage::Application(data) => {
-                                let queued = crate::split_app::SPLIT_APP_RX.try_send(data);
-                                if queued.is_err() {
-                                    warn!("split app message dropped (inbox full)");
-                                }
-                            }
-                            _ => (),
-                        }
+                        // First traffic from the central ⇒ the session is
+                        // bidirectionally live.
+                        app_link.mark_up();
+                        self.handle_central_message(split_message).await;
                     }
                     Err(e) => {
                         error!("Split message read error: {:?}", e);
@@ -313,8 +144,133 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 }
             }
         }
+    }
 
-        // The loop only exits on disconnect.
-        app_link.send(false);
+    /// Process a single message from the central.
+    async fn handle_central_message(&mut self, split_message: SplitMessage) {
+        match split_message {
+            SplitMessage::ConnectionStatus(status) => {
+                trace!("Received central connection status: {:?}", status);
+                update_status(|c| *c = status);
+                // The central sends this only after subscribing to split notifications.
+                #[cfg(feature = "_ble")]
+                self.split_driver
+                    .write(&SplitMessage::BatteryStatus(
+                        crate::input_device::battery::current_battery_status().into(),
+                    ))
+                    .await
+                    .ok();
+            }
+            #[cfg(all(feature = "_ble", feature = "storage"))]
+            SplitMessage::ClearPeer => {
+                // Clear the peer address
+                FLASH_CHANNEL
+                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
+                        0, false, [0; 6],
+                    )))
+                    .await;
+            }
+            SplitMessage::KeyboardIndicator(indicator) => {
+                // Publish KeyboardIndicator event
+                publish_event(LedIndicatorEvent::new(
+                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
+                ));
+            }
+            SplitMessage::Layer(layer) => {
+                // Publish Layer event
+                publish_event(LayerChangeEvent::new(layer));
+            }
+            #[cfg(feature = "display")]
+            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
+            #[cfg(feature = "display")]
+            SplitMessage::Modifier(bits) => {
+                publish_event(ModifierEvent {
+                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
+                });
+            }
+            #[cfg(feature = "display")]
+            SplitMessage::SleepState(sleeping) => {
+                publish_event(SleepStateEvent::new(sleeping));
+            }
+            // --- dfu_split: firmware update handlers ---
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareHashQuery => {
+                let hash = crate::dfu::read_embedded_firmware_hash();
+                info!("dfu_split: hash query, responding with {:#x}", hash);
+                self.split_driver
+                    .write(&SplitMessage::FirmwareHashResponse(hash))
+                    .await
+                    .ok();
+            }
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareChunk { offset, len, data } => {
+                if self.dfu_handler.is_none() {
+                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                    if self.dfu_handler.is_none() {
+                        error!("dfu_split: FlashManager not initialized, skipping chunk");
+                        return;
+                    }
+                }
+                let handler = self.dfu_handler.as_mut().unwrap();
+                let actual_len = len as usize;
+                let chunk_data = &data.0[..actual_len];
+                match handler.write_chunk(offset as u32, chunk_data) {
+                    Ok(()) => {
+                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
+                        let ack = SplitMessage::FirmwareChunkAck {
+                            offset,
+                            crc: crate::crc32::crc32(chunk_data),
+                        };
+                        self.split_driver.write(&ack).await.ok();
+                    }
+                    Err(()) => error!("dfu_split: write error at offset {}", offset),
+                }
+            }
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareUpdateComplete => {
+                if let Some(ref mut handler) = self.dfu_handler {
+                    let dfu_crc = handler.compute_dfu_crc();
+                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
+                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
+                    self.split_driver.write(&crc_msg).await.ok();
+                    info!("dfu_split: CRC report sent");
+
+                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
+                    let ok = loop {
+                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await {
+                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
+                                info!("dfu_split: central confirmed CRC, resetting");
+                                break true;
+                            }
+                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
+                                warn!("dfu_split: central rejected CRC, stopping update");
+                                break false;
+                            }
+                            Either::First(Ok(_)) => {}
+                            Either::First(Err(e)) => {
+                                error!("read error: {:?}", e);
+                                break false;
+                            }
+                            Either::Second(_) => {
+                                error!("timeout");
+                                break false;
+                            }
+                        }
+                    };
+
+                    if ok {
+                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
+                        embassy_time::Timer::after_millis(50).await;
+                        handler.mark_updated_and_reset().ok();
+                    } else {
+                        self.dfu_handler = None;
+                    }
+                } else {
+                    error!("dfu_split: no active DFU session");
+                }
+            }
+            SplitMessage::Application(data) => crate::split_app::deliver_received(data),
+            _ => (),
+        }
     }
 }

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -292,7 +292,8 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                             // split read loop (the application resyncs on
                             // reconnect and must tolerate loss).
                             SplitMessage::Application(data) => {
-                                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                                let queued = crate::split_app::SPLIT_APP_RX.try_send(data);
+                                if queued.is_err() {
                                     warn!("split app message dropped (inbox full)");
                                 }
                             }

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -86,39 +86,14 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
     /// The peripheral uses the general matrix, does scanning and sends key events through `SplitWriter`.
     /// It also receives split messages from the central through `SplitReader`.
     pub(crate) async fn run(&mut self) {
-        // Expose the split-link state to the application.
-        // `run` executes exactly while a central session is up (for BLE it is
-        // invoked per connection and returns on disconnect).
-        //
-        // As on the central side (split/driver.rs), the link-down edge MUST
-        // come from a drop guard: this future can be cancelled from outside
-        // when the session dies, so no in-line `send(false)` is guaranteed to
-        // run. Without the false edge, reconnects look like true->true and
-        // link-up-triggered behavior (e.g. the version announcement) never
-        // re-arms.
-        //
-        // The link-UP edge is deliberately NOT sent here at session start:
-        // for BLE the connection is up, but the central has not yet
-        // subscribed to the peripheral's notify characteristic (CCCD write),
-        // and trouble-host silently drops notifications to an unsubscribed
-        // peer — anything the application sent in that window would vanish.
-        // Instead, link-up is declared on the FIRST message received from
-        // the central: the central's `PeripheralManager` sends its
-        // `ConnectionStatus` snapshot immediately after subscribing, and ATT
-        // bearer ordering guarantees the CCCD write was processed before
-        // that message, so peripheral → central traffic is deliverable from
-        // this point on. (Serial split has no subscription step and reaches
-        // the same first message; the edge is simply "the session is
-        // bidirectionally live".)
-        struct LinkDownGuard;
-        impl Drop for LinkDownGuard {
-            fn drop(&mut self) {
-                crate::split_app::SPLIT_APP_LINK.sender().send(false);
-            }
-        }
-        let _link_guard = LinkDownGuard;
-        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
-        let mut link_up_sent = false;
+        // `run` executes exactly while a central session is up; the guard's
+        // `Drop` sends the link-down edge even when this future is cancelled
+        // from outside. Link-up waits for the first message from the central:
+        // a bare BLE connection is not enough, since trouble-host silently
+        // drops notifications until the central subscribes (CCCD write), and
+        // the central's `ConnectionStatus` snapshot arrives right after it
+        // subscribes — so first message ⇒ bidirectionally live.
+        let mut app_link = crate::split_app::LinkGuard::new();
 
         // Proactively announce our firmware hash so the central can detect
         // us even when it booted first and already gave up waiting for a query response.
@@ -150,9 +125,7 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                     },
                     e = pointing_sub.next_message_pure().fuse() => SplitMessage::Pointing(e),
                     with_feature("_ble"): e = battery_sub.next_event().fuse() => SplitMessage::BatteryStatus(e),
-                    // Peripheral → central application
-                    // messages, deliberately the last (lowest-priority)
-                    // outgoing arm behind key events.
+                    // Deliberately the last (lowest-priority) outgoing arm, behind key events.
                     m = crate::split_app::SPLIT_APP_PERIPH_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
@@ -161,146 +134,10 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 Either::First(m) => match m {
                     // Process split messages from the central
                     Ok(split_message) => {
-                        // First traffic from the central ⇒ the
-                        // session is bidirectionally live (see the LinkDownGuard
-                        // comment above for why link-up is not sent at start).
-                        if !link_up_sent {
-                            app_link.send(true);
-                            link_up_sent = true;
-                        }
-                        match split_message {
-                            SplitMessage::ConnectionStatus(status) => {
-                                trace!("Received central connection status: {:?}", status);
-                                update_status(|c| *c = status);
-                                // The central sends this only after subscribing to split notifications.
-                                #[cfg(feature = "_ble")]
-                                self.split_driver
-                                    .write(&SplitMessage::BatteryStatus(
-                                        crate::input_device::battery::current_battery_status().into(),
-                                    ))
-                                    .await
-                                    .ok();
-                            }
-                            #[cfg(all(feature = "_ble", feature = "storage"))]
-                            SplitMessage::ClearPeer => {
-                                // Clear the peer address
-                                FLASH_CHANNEL
-                                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
-                                        0, false, [0; 6],
-                                    )))
-                                    .await;
-                            }
-                            SplitMessage::KeyboardIndicator(indicator) => {
-                                // Publish KeyboardIndicator event
-                                publish_event(LedIndicatorEvent::new(
-                                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
-                                ));
-                            }
-                            SplitMessage::Layer(layer) => {
-                                // Publish Layer event
-                                publish_event(LayerChangeEvent::new(layer));
-                            }
-                            #[cfg(feature = "display")]
-                            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
-                            #[cfg(feature = "display")]
-                            SplitMessage::Modifier(bits) => {
-                                publish_event(ModifierEvent {
-                                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
-                                });
-                            }
-                            SplitMessage::SleepState(sleeping) => {
-                                publish_event(SleepStateEvent::new(sleeping));
-                            }
-                            // --- dfu_split: firmware update handlers ---
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareHashQuery => {
-                                let hash = crate::dfu::read_embedded_firmware_hash();
-                                info!("dfu_split: hash query, responding with {:#x}", hash);
-                                self.split_driver
-                                    .write(&SplitMessage::FirmwareHashResponse(hash))
-                                    .await
-                                    .ok();
-                            }
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareChunk { offset, len, data } => {
-                                if self.dfu_handler.is_none() {
-                                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
-                                    if self.dfu_handler.is_none() {
-                                        error!("dfu_split: FlashManager not initialized, skipping chunk");
-                                        continue;
-                                    }
-                                }
-                                let handler = self.dfu_handler.as_mut().unwrap();
-                                let actual_len = len as usize;
-                                let chunk_data = &data.0[..actual_len];
-                                match handler.write_chunk(offset as u32, chunk_data) {
-                                    Ok(()) => {
-                                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
-                                        let ack = SplitMessage::FirmwareChunkAck {
-                                            offset,
-                                            crc: crate::crc32::crc32(chunk_data),
-                                        };
-                                        self.split_driver.write(&ack).await.ok();
-                                    }
-                                    Err(()) => error!("dfu_split: write error at offset {}", offset),
-                                }
-                            }
-                            #[cfg(feature = "dfu_split")]
-                            SplitMessage::FirmwareUpdateComplete => {
-                                if let Some(ref mut handler) = self.dfu_handler {
-                                    let dfu_crc = handler.compute_dfu_crc();
-                                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
-                                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
-                                    self.split_driver.write(&crc_msg).await.ok();
-                                    info!("dfu_split: CRC report sent");
-
-                                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
-                                    let ok = loop {
-                                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await
-                                        {
-                                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
-                                                info!("dfu_split: central confirmed CRC, resetting");
-                                                break true;
-                                            }
-                                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
-                                                warn!("dfu_split: central rejected CRC, stopping update");
-                                                break false;
-                                            }
-                                            Either::First(Ok(_)) => {}
-                                            Either::First(Err(e)) => {
-                                                error!("read error: {:?}", e);
-                                                break false;
-                                            }
-                                            Either::Second(_) => {
-                                                error!("timeout");
-                                                break false;
-                                            }
-                                        }
-                                    };
-
-                                    if ok {
-                                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
-                                        embassy_time::Timer::after_millis(50).await;
-                                        handler.mark_updated_and_reset().ok();
-                                    } else {
-                                        self.dfu_handler = None;
-                                    }
-                                } else {
-                                    error!("dfu_split: no active DFU session");
-                                }
-                            }
-                            // Forward application payloads;
-                            // drop-on-full so a slow consumer can never stall the
-                            // split read loop (the application resyncs on
-                            // reconnect and must tolerate loss).
-                            SplitMessage::Application(data) => {
-                                let queued = crate::split_app::SPLIT_APP_RX.try_send(data);
-                                if queued.is_err() {
-                                    warn!("split app message dropped (inbox full)");
-                                }
-                            }
-                            _ => (),
-                        }
+                        // First traffic from the central ⇒ the session is
+                        // bidirectionally live.
+                        app_link.mark_up();
+                        self.handle_central_message(split_message).await;
                     }
                     Err(e) => {
                         error!("Split message read error: {:?}", e);
@@ -315,8 +152,132 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 }
             }
         }
+    }
 
-        // The loop only exits on disconnect.
-        app_link.send(false);
+    /// Process a single message from the central.
+    async fn handle_central_message(&mut self, split_message: SplitMessage) {
+        match split_message {
+            SplitMessage::ConnectionStatus(status) => {
+                trace!("Received central connection status: {:?}", status);
+                update_status(|c| *c = status);
+                // The central sends this only after subscribing to split notifications.
+                #[cfg(feature = "_ble")]
+                self.split_driver
+                    .write(&SplitMessage::BatteryStatus(
+                        crate::input_device::battery::current_battery_status().into(),
+                    ))
+                    .await
+                    .ok();
+            }
+            #[cfg(all(feature = "_ble", feature = "storage"))]
+            SplitMessage::ClearPeer => {
+                // Clear the peer address
+                FLASH_CHANNEL
+                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
+                        0, false, [0; 6],
+                    )))
+                    .await;
+            }
+            SplitMessage::KeyboardIndicator(indicator) => {
+                // Publish KeyboardIndicator event
+                publish_event(LedIndicatorEvent::new(
+                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
+                ));
+            }
+            SplitMessage::Layer(layer) => {
+                // Publish Layer event
+                publish_event(LayerChangeEvent::new(layer));
+            }
+            #[cfg(feature = "display")]
+            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
+            #[cfg(feature = "display")]
+            SplitMessage::Modifier(bits) => {
+                publish_event(ModifierEvent {
+                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
+                });
+            }
+            SplitMessage::SleepState(sleeping) => {
+                publish_event(SleepStateEvent::new(sleeping));
+            }
+            // --- dfu_split: firmware update handlers ---
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareHashQuery => {
+                let hash = crate::dfu::read_embedded_firmware_hash();
+                info!("dfu_split: hash query, responding with {:#x}", hash);
+                self.split_driver
+                    .write(&SplitMessage::FirmwareHashResponse(hash))
+                    .await
+                    .ok();
+            }
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareChunk { offset, len, data } => {
+                if self.dfu_handler.is_none() {
+                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                    if self.dfu_handler.is_none() {
+                        error!("dfu_split: FlashManager not initialized, skipping chunk");
+                        return;
+                    }
+                }
+                let handler = self.dfu_handler.as_mut().unwrap();
+                let actual_len = len as usize;
+                let chunk_data = &data.0[..actual_len];
+                match handler.write_chunk(offset as u32, chunk_data) {
+                    Ok(()) => {
+                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
+                        let ack = SplitMessage::FirmwareChunkAck {
+                            offset,
+                            crc: crate::crc32::crc32(chunk_data),
+                        };
+                        self.split_driver.write(&ack).await.ok();
+                    }
+                    Err(()) => error!("dfu_split: write error at offset {}", offset),
+                }
+            }
+            #[cfg(feature = "dfu_split")]
+            SplitMessage::FirmwareUpdateComplete => {
+                if let Some(ref mut handler) = self.dfu_handler {
+                    let dfu_crc = handler.compute_dfu_crc();
+                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
+                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
+                    self.split_driver.write(&crc_msg).await.ok();
+                    info!("dfu_split: CRC report sent");
+
+                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
+                    let ok = loop {
+                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await {
+                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
+                                info!("dfu_split: central confirmed CRC, resetting");
+                                break true;
+                            }
+                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
+                                warn!("dfu_split: central rejected CRC, stopping update");
+                                break false;
+                            }
+                            Either::First(Ok(_)) => {}
+                            Either::First(Err(e)) => {
+                                error!("read error: {:?}", e);
+                                break false;
+                            }
+                            Either::Second(_) => {
+                                error!("timeout");
+                                break false;
+                            }
+                        }
+                    };
+
+                    if ok {
+                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
+                        embassy_time::Timer::after_millis(50).await;
+                        handler.mark_updated_and_reset().ok();
+                    } else {
+                        self.dfu_handler = None;
+                    }
+                } else {
+                    error!("dfu_split: no active DFU session");
+                }
+            }
+            SplitMessage::Application(data) => crate::split_app::deliver_received(data),
+            _ => (),
+        }
     }
 }

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -294,7 +294,8 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                             // split read loop (the application resyncs on
                             // reconnect and must tolerate loss).
                             SplitMessage::Application(data) => {
-                                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                                let queued = crate::split_app::SPLIT_APP_RX.try_send(data);
+                                if queued.is_err() {
                                     warn!("split app message dropped (inbox full)");
                                 }
                             }

--- a/rmk/src/split/peripheral.rs
+++ b/rmk/src/split/peripheral.rs
@@ -86,6 +86,40 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
     /// The peripheral uses the general matrix, does scanning and sends key events through `SplitWriter`.
     /// It also receives split messages from the central through `SplitReader`.
     pub(crate) async fn run(&mut self) {
+        // Expose the split-link state to the application.
+        // `run` executes exactly while a central session is up (for BLE it is
+        // invoked per connection and returns on disconnect).
+        //
+        // As on the central side (split/driver.rs), the link-down edge MUST
+        // come from a drop guard: this future can be cancelled from outside
+        // when the session dies, so no in-line `send(false)` is guaranteed to
+        // run. Without the false edge, reconnects look like true->true and
+        // link-up-triggered behavior (e.g. the version announcement) never
+        // re-arms.
+        //
+        // The link-UP edge is deliberately NOT sent here at session start:
+        // for BLE the connection is up, but the central has not yet
+        // subscribed to the peripheral's notify characteristic (CCCD write),
+        // and trouble-host silently drops notifications to an unsubscribed
+        // peer — anything the application sent in that window would vanish.
+        // Instead, link-up is declared on the FIRST message received from
+        // the central: the central's `PeripheralManager` sends its
+        // `ConnectionStatus` snapshot immediately after subscribing, and ATT
+        // bearer ordering guarantees the CCCD write was processed before
+        // that message, so peripheral → central traffic is deliverable from
+        // this point on. (Serial split has no subscription step and reaches
+        // the same first message; the edge is simply "the session is
+        // bidirectionally live".)
+        struct LinkDownGuard;
+        impl Drop for LinkDownGuard {
+            fn drop(&mut self) {
+                crate::split_app::SPLIT_APP_LINK.sender().send(false);
+            }
+        }
+        let _link_guard = LinkDownGuard;
+        let app_link = crate::split_app::SPLIT_APP_LINK.sender();
+        let mut link_up_sent = false;
+
         // Proactively announce our firmware hash so the central can detect
         // us even when it booted first and already gave up waiting for a query response.
         #[cfg(feature = "dfu_split")]
@@ -116,134 +150,157 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                     },
                     e = pointing_sub.next_message_pure().fuse() => SplitMessage::Pointing(e),
                     with_feature("_ble"): e = battery_sub.next_event().fuse() => SplitMessage::BatteryStatus(e),
+                    // Peripheral → central application
+                    // messages, deliberately the last (lowest-priority)
+                    // outgoing arm behind key events.
+                    m = crate::split_app::SPLIT_APP_PERIPH_TX.receive().fuse() => SplitMessage::Application(m),
                 }
             };
 
             match select(self.split_driver.read(), read_message_to_send).await {
                 Either::First(m) => match m {
                     // Process split messages from the central
-                    Ok(split_message) => match split_message {
-                        SplitMessage::ConnectionStatus(status) => {
-                            trace!("Received central connection status: {:?}", status);
-                            update_status(|c| *c = status);
-                            // The central sends this only after subscribing to split notifications.
-                            #[cfg(feature = "_ble")]
-                            self.split_driver
-                                .write(&SplitMessage::BatteryStatus(
-                                    crate::input_device::battery::current_battery_status().into(),
-                                ))
-                                .await
-                                .ok();
+                    Ok(split_message) => {
+                        // First traffic from the central ⇒ the
+                        // session is bidirectionally live (see the LinkDownGuard
+                        // comment above for why link-up is not sent at start).
+                        if !link_up_sent {
+                            app_link.send(true);
+                            link_up_sent = true;
                         }
-                        #[cfg(all(feature = "_ble", feature = "storage"))]
-                        SplitMessage::ClearPeer => {
-                            // Clear the peer address
-                            FLASH_CHANNEL
-                                .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
-                                    0, false, [0; 6],
-                                )))
-                                .await;
-                        }
-                        SplitMessage::KeyboardIndicator(indicator) => {
-                            // Publish KeyboardIndicator event
-                            publish_event(LedIndicatorEvent::new(
-                                rmk_types::led_indicator::LedIndicator::from_bits(indicator),
-                            ));
-                        }
-                        SplitMessage::Layer(layer) => {
-                            // Publish Layer event
-                            publish_event(LayerChangeEvent::new(layer));
-                        }
-                        #[cfg(feature = "display")]
-                        SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
-                        #[cfg(feature = "display")]
-                        SplitMessage::Modifier(bits) => {
-                            publish_event(ModifierEvent {
-                                modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
-                            });
-                        }
-                        SplitMessage::SleepState(sleeping) => {
-                            publish_event(SleepStateEvent::new(sleeping));
-                        }
-                        // --- dfu_split: firmware update handlers ---
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareHashQuery => {
-                            let hash = crate::dfu::read_embedded_firmware_hash();
-                            info!("dfu_split: hash query, responding with {:#x}", hash);
-                            self.split_driver
-                                .write(&SplitMessage::FirmwareHashResponse(hash))
-                                .await
-                                .ok();
-                        }
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareChunk { offset, len, data } => {
-                            if self.dfu_handler.is_none() {
-                                self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                        match split_message {
+                            SplitMessage::ConnectionStatus(status) => {
+                                trace!("Received central connection status: {:?}", status);
+                                update_status(|c| *c = status);
+                                // The central sends this only after subscribing to split notifications.
+                                #[cfg(feature = "_ble")]
+                                self.split_driver
+                                    .write(&SplitMessage::BatteryStatus(
+                                        crate::input_device::battery::current_battery_status().into(),
+                                    ))
+                                    .await
+                                    .ok();
+                            }
+                            #[cfg(all(feature = "_ble", feature = "storage"))]
+                            SplitMessage::ClearPeer => {
+                                // Clear the peer address
+                                FLASH_CHANNEL
+                                    .send(crate::storage::FlashOperationMessage::PeerAddress(PeerAddress::new(
+                                        0, false, [0; 6],
+                                    )))
+                                    .await;
+                            }
+                            SplitMessage::KeyboardIndicator(indicator) => {
+                                // Publish KeyboardIndicator event
+                                publish_event(LedIndicatorEvent::new(
+                                    rmk_types::led_indicator::LedIndicator::from_bits(indicator),
+                                ));
+                            }
+                            SplitMessage::Layer(layer) => {
+                                // Publish Layer event
+                                publish_event(LayerChangeEvent::new(layer));
+                            }
+                            #[cfg(feature = "display")]
+                            SplitMessage::Wpm(wpm) => publish_event(WpmUpdateEvent::new(wpm)),
+                            #[cfg(feature = "display")]
+                            SplitMessage::Modifier(bits) => {
+                                publish_event(ModifierEvent {
+                                    modifier: rmk_types::modifier::ModifierCombination::from_bits(bits),
+                                });
+                            }
+                            SplitMessage::SleepState(sleeping) => {
+                                publish_event(SleepStateEvent::new(sleeping));
+                            }
+                            // --- dfu_split: firmware update handlers ---
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareHashQuery => {
+                                let hash = crate::dfu::read_embedded_firmware_hash();
+                                info!("dfu_split: hash query, responding with {:#x}", hash);
+                                self.split_driver
+                                    .write(&SplitMessage::FirmwareHashResponse(hash))
+                                    .await
+                                    .ok();
+                            }
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareChunk { offset, len, data } => {
                                 if self.dfu_handler.is_none() {
-                                    error!("dfu_split: FlashManager not initialized, skipping chunk");
-                                    continue;
-                                }
-                            }
-                            let handler = self.dfu_handler.as_mut().unwrap();
-                            let actual_len = len as usize;
-                            let chunk_data = &data.0[..actual_len];
-                            match handler.write_chunk(offset as u32, chunk_data) {
-                                Ok(()) => {
-                                    debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
-                                    let ack = SplitMessage::FirmwareChunkAck {
-                                        offset,
-                                        crc: crate::crc32::crc32(chunk_data),
-                                    };
-                                    self.split_driver.write(&ack).await.ok();
-                                }
-                                Err(()) => error!("dfu_split: write error at offset {}", offset),
-                            }
-                        }
-                        #[cfg(feature = "dfu_split")]
-                        SplitMessage::FirmwareUpdateComplete => {
-                            if let Some(ref mut handler) = self.dfu_handler {
-                                let dfu_crc = handler.compute_dfu_crc();
-                                info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
-                                let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
-                                self.split_driver.write(&crc_msg).await.ok();
-                                info!("dfu_split: CRC report sent");
-
-                                let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
-                                let ok = loop {
-                                    match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await {
-                                        Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
-                                            info!("dfu_split: central confirmed CRC, resetting");
-                                            break true;
-                                        }
-                                        Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
-                                            warn!("dfu_split: central rejected CRC, stopping update");
-                                            break false;
-                                        }
-                                        Either::First(Ok(_)) => {}
-                                        Either::First(Err(e)) => {
-                                            error!("read error: {:?}", e);
-                                            break false;
-                                        }
-                                        Either::Second(_) => {
-                                            error!("timeout");
-                                            break false;
-                                        }
+                                    self.dfu_handler = crate::dfu::SplitDfuHandler::new();
+                                    if self.dfu_handler.is_none() {
+                                        error!("dfu_split: FlashManager not initialized, skipping chunk");
+                                        continue;
                                     }
-                                };
-
-                                if ok {
-                                    self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
-                                    embassy_time::Timer::after_millis(50).await;
-                                    handler.mark_updated_and_reset().ok();
-                                } else {
-                                    self.dfu_handler = None;
                                 }
-                            } else {
-                                error!("dfu_split: no active DFU session");
+                                let handler = self.dfu_handler.as_mut().unwrap();
+                                let actual_len = len as usize;
+                                let chunk_data = &data.0[..actual_len];
+                                match handler.write_chunk(offset as u32, chunk_data) {
+                                    Ok(()) => {
+                                        debug!("dfu_split: wrote {} bytes at offset {}", actual_len, offset);
+                                        let ack = SplitMessage::FirmwareChunkAck {
+                                            offset,
+                                            crc: crate::crc32::crc32(chunk_data),
+                                        };
+                                        self.split_driver.write(&ack).await.ok();
+                                    }
+                                    Err(()) => error!("dfu_split: write error at offset {}", offset),
+                                }
                             }
+                            #[cfg(feature = "dfu_split")]
+                            SplitMessage::FirmwareUpdateComplete => {
+                                if let Some(ref mut handler) = self.dfu_handler {
+                                    let dfu_crc = handler.compute_dfu_crc();
+                                    info!("dfu_split: DFU partition CRC: {:#010x}", dfu_crc);
+                                    let crc_msg = SplitMessage::FirmwareCrcReport(dfu_crc);
+                                    self.split_driver.write(&crc_msg).await.ok();
+                                    info!("dfu_split: CRC report sent");
+
+                                    let deadline = embassy_time::Instant::now() + embassy_time::Duration::from_secs(5);
+                                    let ok = loop {
+                                        match select(self.split_driver.read(), embassy_time::Timer::at(deadline)).await
+                                        {
+                                            Either::First(Ok(SplitMessage::FirmwareCrcOk)) => {
+                                                info!("dfu_split: central confirmed CRC, resetting");
+                                                break true;
+                                            }
+                                            Either::First(Ok(SplitMessage::FirmwareCrcFail)) => {
+                                                warn!("dfu_split: central rejected CRC, stopping update");
+                                                break false;
+                                            }
+                                            Either::First(Ok(_)) => {}
+                                            Either::First(Err(e)) => {
+                                                error!("read error: {:?}", e);
+                                                break false;
+                                            }
+                                            Either::Second(_) => {
+                                                error!("timeout");
+                                                break false;
+                                            }
+                                        }
+                                    };
+
+                                    if ok {
+                                        self.split_driver.write(&SplitMessage::FirmwareUpdateConfirm).await.ok();
+                                        embassy_time::Timer::after_millis(50).await;
+                                        handler.mark_updated_and_reset().ok();
+                                    } else {
+                                        self.dfu_handler = None;
+                                    }
+                                } else {
+                                    error!("dfu_split: no active DFU session");
+                                }
+                            }
+                            // Forward application payloads;
+                            // drop-on-full so a slow consumer can never stall the
+                            // split read loop (the application resyncs on
+                            // reconnect and must tolerate loss).
+                            SplitMessage::Application(data) => {
+                                if crate::split_app::SPLIT_APP_RX.try_send(data).is_err() {
+                                    warn!("split app message dropped (inbox full)");
+                                }
+                            }
+                            _ => (),
                         }
-                        _ => (),
-                    },
+                    }
                     Err(e) => {
                         error!("Split message read error: {:?}", e);
                         if let crate::split::driver::SplitDriverError::Disconnected = e {
@@ -257,5 +314,8 @@ impl<S: SplitWriter + SplitReader> SplitPeripheral<S> {
                 }
             }
         }
+
+        // The loop only exits on disconnect.
+        app_link.send(false);
     }
 }

--- a/rmk/src/split_app.rs
+++ b/rmk/src/split_app.rs
@@ -1,0 +1,124 @@
+//! Bounded application-message hook for the split protocol.
+//!
+//! A small, opaque, bounded payload that an application can send between the
+//! split central and its peripheral alongside — but never in front of — the
+//! normal split traffic. RMK itself attaches no meaning to the bytes; a
+//! firmware built on RMK can use it for application-level side-band state
+//! (for example, propagating lighting or UI state across the split link).
+//!
+//! Flow:
+//!
+//! - Central: the application queues [`SplitAppData`] into [`SPLIT_APP_TX`]
+//!   (bounded, `try_send` only — the queue must never be awaited full).
+//!   `PeripheralManager` drains it as one more (lowest-priority) arm of its
+//!   outgoing-message select and wraps each payload in
+//!   `SplitMessage::Application`. Peripheral→central key events always win:
+//!   they arrive on the read arm, which is polled first.
+//! - Peripheral: `SplitPeripheral` forwards received `Application` messages
+//!   into [`SPLIT_APP_RX`] with `try_send` (drop-on-full keeps the split read
+//!   loop responsive; the application is expected to tolerate loss, e.g. by
+//!   resyncing on reconnect).
+//! - Peripheral → central: the peripheral application queues
+//!   [`SplitAppData`] into [`SPLIT_APP_PERIPH_TX`] (bounded, `try_send`
+//!   only); `SplitPeripheral` drains it as one more outgoing arm of its
+//!   select, behind key events. The central's `PeripheralManager` forwards
+//!   received `Application` messages into [`SPLIT_APP_RX`] the same way the
+//!   peripheral does — the inbox is symmetric ("this side's received
+//!   application messages"), only the senders differ.
+//! - Both sides: [`SPLIT_APP_LINK`] carries the split-link state (central:
+//!   "peripheral link up"; peripheral: "central link up"), set by the split
+//!   driver. The central raises it at session start; the peripheral raises
+//!   it on the FIRST message received from the central — for BLE the bare
+//!   connection is not enough, since notifications to a central that has
+//!   not yet subscribed are silently dropped (see `split/peripheral.rs`).
+//!   Both lower it at session end. Applications use the `false → true` edge
+//!   to trigger an idempotent resync.
+//!
+//! Note: the queues assume a single split peripheral. Extending this hook to
+//! multiple peripherals would key them by peripheral id.
+
+use embassy_sync::channel::Channel;
+use embassy_sync::watch::Watch;
+use postcard::experimental::max_size::MaxSize;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::RawMutex;
+
+/// Maximum payload of one application split message. Deliberately small:
+/// every split BLE transfer is `SPLIT_MESSAGE_MAX_SIZE` bytes on the wire,
+/// so this bound also taxes key-event messages. Hard cap: the trouble
+/// `gatt_service` macro initializes its characteristic arrays via
+/// `Default`, which arrays only implement up to 32 elements — so
+/// `SPLIT_MESSAGE_MAX_SIZE` (this + 1-byte length prefix + 1-byte enum
+/// discriminant + 4 bytes margin) must stay ≤ 32.
+pub const SPLIT_APP_MSG_MAX: usize = 26;
+
+/// One opaque application payload. Only `data[..len]` is meaningful.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SplitAppData {
+    pub len: u8,
+    pub data: [u8; SPLIT_APP_MSG_MAX],
+}
+
+impl SplitAppData {
+    /// Wrap `payload`; `None` if it exceeds [`SPLIT_APP_MSG_MAX`].
+    pub fn new(payload: &[u8]) -> Option<Self> {
+        if payload.len() > SPLIT_APP_MSG_MAX {
+            return None;
+        }
+        let mut data = [0u8; SPLIT_APP_MSG_MAX];
+        data[..payload.len()].copy_from_slice(payload);
+        Some(Self {
+            len: payload.len() as u8,
+            data,
+        })
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.data[..(self.len as usize).min(SPLIT_APP_MSG_MAX)]
+    }
+}
+
+// Postcard stores the payload as `&[u8]` (varint length prefix + bytes), so
+// only the used bytes travel inside the (fixed-size) split transfer buffer.
+impl Serialize for SplitAppData {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.payload().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SplitAppData {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+        let buf: &[u8] = Deserialize::deserialize(deserializer)?;
+        SplitAppData::new(buf).ok_or_else(|| D::Error::custom("split app message too long"))
+    }
+}
+
+impl MaxSize for SplitAppData {
+    // 1-byte varint length prefix + payload.
+    const POSTCARD_MAX_SIZE: usize = SPLIT_APP_MSG_MAX + 1;
+}
+
+/// Central → peripheral queue, drained by `PeripheralManager` while the link
+/// is up. Producers MUST use `try_send` (bounded, never block); capacity is
+/// sized so one full application resync burst fits with headroom.
+pub static SPLIT_APP_TX: Channel<RawMutex, SplitAppData, 26> = Channel::new();
+
+/// This side's inbox of received application messages (peripheral: from the
+/// central's `SPLIT_APP_TX`; central: from the peripheral's
+/// `SPLIT_APP_PERIPH_TX`). Filled with `try_send` (drop-on-full) by the
+/// split read loops.
+pub static SPLIT_APP_RX: Channel<RawMutex, SplitAppData, 8> = Channel::new();
+
+/// Peripheral → central queue, drained by `SplitPeripheral` while the link
+/// is up. Producers MUST use `try_send`. Small: the application announces
+/// tiny, rare state (e.g. its build identity once per link-up).
+pub static SPLIT_APP_PERIPH_TX: Channel<RawMutex, SplitAppData, 2> = Channel::new();
+
+/// Split-link state for the application: on the central, "peripheral link
+/// up"; on the peripheral, "central link up". Written by the split driver at
+/// session start/end; state-based (a late receiver still observes the latest
+/// value), so edges cannot be lost the way pub/sub events can.
+pub static SPLIT_APP_LINK: Watch<RawMutex, bool, 2> = Watch::new();

--- a/rmk/src/split_app.rs
+++ b/rmk/src/split_app.rs
@@ -1,41 +1,18 @@
 //! Bounded application-message hook for the split protocol.
 //!
-//! A small, opaque, bounded payload that an application can send between the
-//! split central and its peripheral alongside — but never in front of — the
-//! normal split traffic. RMK itself attaches no meaning to the bytes; a
-//! firmware built on RMK can use it for application-level side-band state
-//! (for example, propagating lighting or UI state across the split link).
+//! An application built on RMK can exchange small opaque payloads
+//! ([`SplitAppData`]) between the split halves alongside — but never in front
+//! of — normal split traffic. RMK attaches no meaning to the bytes.
 //!
-//! Flow:
+//! Each side queues outgoing payloads with `try_send` ([`SPLIT_APP_TX`] on
+//! the central, [`SPLIT_APP_PERIPH_TX`] on the peripheral). The split loops
+//! drain them as their lowest-priority outgoing arm and deliver received
+//! payloads into [`SPLIT_APP_RX`], dropping on full so application traffic
+//! can never delay key events. [`SPLIT_APP_LINK`] carries the link state; its
+//! `false → true` edge is the application's cue to resync, which also covers
+//! messages lost to a full queue.
 //!
-//! - Central: the application queues [`SplitAppData`] into [`SPLIT_APP_TX`]
-//!   (bounded, `try_send` only — the queue must never be awaited full).
-//!   `PeripheralManager` drains it as one more (lowest-priority) arm of its
-//!   outgoing-message select and wraps each payload in
-//!   `SplitMessage::Application`. Peripheral→central key events always win:
-//!   they arrive on the read arm, which is polled first.
-//! - Peripheral: `SplitPeripheral` forwards received `Application` messages
-//!   into [`SPLIT_APP_RX`] with `try_send` (drop-on-full keeps the split read
-//!   loop responsive; the application is expected to tolerate loss, e.g. by
-//!   resyncing on reconnect).
-//! - Peripheral → central: the peripheral application queues
-//!   [`SplitAppData`] into [`SPLIT_APP_PERIPH_TX`] (bounded, `try_send`
-//!   only); `SplitPeripheral` drains it as one more outgoing arm of its
-//!   select, behind key events. The central's `PeripheralManager` forwards
-//!   received `Application` messages into [`SPLIT_APP_RX`] the same way the
-//!   peripheral does — the inbox is symmetric ("this side's received
-//!   application messages"), only the senders differ.
-//! - Both sides: [`SPLIT_APP_LINK`] carries the split-link state (central:
-//!   "peripheral link up"; peripheral: "central link up"), set by the split
-//!   driver. The central raises it at session start; the peripheral raises
-//!   it on the FIRST message received from the central — for BLE the bare
-//!   connection is not enough, since notifications to a central that has
-//!   not yet subscribed are silently dropped (see `split/peripheral.rs`).
-//!   Both lower it at session end. Applications use the `false → true` edge
-//!   to trigger an idempotent resync.
-//!
-//! Note: the queues assume a single split peripheral. Extending this hook to
-//! multiple peripherals would key them by peripheral id.
+//! The queues assume a single split peripheral.
 
 use embassy_sync::channel::Channel;
 use embassy_sync::watch::Watch;
@@ -44,13 +21,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::RawMutex;
 
-/// Maximum payload of one application split message. Deliberately small:
-/// every split BLE transfer is `SPLIT_MESSAGE_MAX_SIZE` bytes on the wire,
-/// so this bound also taxes key-event messages. Hard cap: the trouble
-/// `gatt_service` macro initializes its characteristic arrays via
-/// `Default`, which arrays only implement up to 32 elements — so
-/// `SPLIT_MESSAGE_MAX_SIZE` (this + 1-byte length prefix + 1-byte enum
-/// discriminant + 4 bytes margin) must stay ≤ 32.
+/// Maximum payload of one application split message. Every split transfer is
+/// `SPLIT_MESSAGE_MAX_SIZE` bytes on the wire, and trouble's `gatt_service`
+/// macro caps that at 32 (it initializes characteristic arrays via `Default`,
+/// which arrays only implement up to 32 elements), so this plus postcard
+/// overhead must keep `SPLIT_MESSAGE_MAX_SIZE` ≤ 32.
 pub const SPLIT_APP_MSG_MAX: usize = 26;
 
 /// One opaque application payload. Only `data[..len]` is meaningful.
@@ -101,24 +76,56 @@ impl MaxSize for SplitAppData {
     const POSTCARD_MAX_SIZE: usize = SPLIT_APP_MSG_MAX + 1;
 }
 
-/// Central → peripheral queue, drained by `PeripheralManager` while the link
-/// is up. Producers MUST use `try_send` (bounded, never block); capacity is
-/// sized so one full application resync burst fits with headroom.
+/// Central → peripheral queue. Producers must use `try_send` (never await a
+/// full queue); capacity fits one full application resync burst.
 pub static SPLIT_APP_TX: Channel<RawMutex, SplitAppData, 26> = Channel::new();
 
-/// This side's inbox of received application messages (peripheral: from the
-/// central's `SPLIT_APP_TX`; central: from the peripheral's
-/// `SPLIT_APP_PERIPH_TX`). Filled with `try_send` (drop-on-full) by the
-/// split read loops.
+/// This side's inbox of received application messages. Filled with `try_send`
+/// (drop-on-full) by the split read loops.
 pub static SPLIT_APP_RX: Channel<RawMutex, SplitAppData, 8> = Channel::new();
 
-/// Peripheral → central queue, drained by `SplitPeripheral` while the link
-/// is up. Producers MUST use `try_send`. Small: the application announces
-/// tiny, rare state (e.g. its build identity once per link-up).
+/// Peripheral → central queue. Producers must use `try_send`. Small: meant
+/// for tiny, rare state such as a build identity announced once per link-up.
 pub static SPLIT_APP_PERIPH_TX: Channel<RawMutex, SplitAppData, 2> = Channel::new();
 
-/// Split-link state for the application: on the central, "peripheral link
-/// up"; on the peripheral, "central link up". Written by the split driver at
-/// session start/end; state-based (a late receiver still observes the latest
-/// value), so edges cannot be lost the way pub/sub events can.
+/// Deliver a received payload into [`SPLIT_APP_RX`]. Drop-on-full: a slow
+/// application consumer must never stall the split read loops, and the
+/// application resyncs on reconnect anyway.
+pub(crate) fn deliver_received(data: SplitAppData) {
+    if SPLIT_APP_RX.try_send(data).is_err() {
+        warn!("split app message dropped (inbox full)");
+    }
+}
+
+/// Split-link state for the application, written by the split loops via
+/// [`LinkGuard`]. State-based, so a late receiver still observes the current
+/// value.
 pub static SPLIT_APP_LINK: Watch<RawMutex, bool, 2> = Watch::new();
+
+/// Owns one split session's [`SPLIT_APP_LINK`] state: `mark_up` sends the
+/// link-up edge once, and `Drop` sends the link-down edge. The down edge must
+/// come from `Drop` because the session futures holding a guard are cancelled
+/// from outside on connection loss.
+pub(crate) struct LinkGuard {
+    up: bool,
+}
+
+impl LinkGuard {
+    pub(crate) fn new() -> Self {
+        Self { up: false }
+    }
+
+    /// Send the link-up edge; idempotent.
+    pub(crate) fn mark_up(&mut self) {
+        if !self.up {
+            SPLIT_APP_LINK.sender().send(true);
+            self.up = true;
+        }
+    }
+}
+
+impl Drop for LinkGuard {
+    fn drop(&mut self) {
+        SPLIT_APP_LINK.sender().send(false);
+    }
+}

--- a/rmk/src/split_app.rs
+++ b/rmk/src/split_app.rs
@@ -82,11 +82,15 @@ pub static SPLIT_APP_TX: Channel<RawMutex, SplitAppData, 26> = Channel::new();
 
 /// This side's inbox of received application messages. Filled with `try_send`
 /// (drop-on-full) by the split read loops.
-pub static SPLIT_APP_RX: Channel<RawMutex, SplitAppData, 8> = Channel::new();
+// Sized like SPLIT_APP_TX: an application snapshot arrives as one
+// back-to-back burst, and unlike BLE a wired transport delivers it faster
+// than the consumer drains, so the burst must fit or `deliver_received`
+// silently drops the difference.
+pub static SPLIT_APP_RX: Channel<RawMutex, SplitAppData, 112> = Channel::new();
 
 /// Peripheral → central queue. Producers must use `try_send`. Small: meant
 /// for tiny, rare state such as a build identity announced once per link-up.
-pub static SPLIT_APP_PERIPH_TX: Channel<RawMutex, SplitAppData, 2> = Channel::new();
+pub static SPLIT_APP_PERIPH_TX: Channel<RawMutex, SplitAppData, 16> = Channel::new();
 
 /// Deliver a received payload into [`SPLIT_APP_RX`]. Drop-on-full: a slow
 /// application consumer must never stall the split read loops, and the


### PR DESCRIPTION
## What

- add a 26-byte opaque application payload to the split wire protocol
- expose bounded central-to-peripheral, peripheral-to-central, and receive queues
- expose split-link state so applications can resynchronize after reconnects
- keep key events ahead of application traffic and use drop-on-full semantics to preserve split responsiveness

## Why

RMK-based firmware sometimes needs to coordinate application-owned state across halves without adding hardware-specific meaning to the core split protocol. Per-key lighting is one consumer, but this API stays opaque and allocation-free.

## Impact

Existing split behavior is unchanged unless the new queues are used. The implementation currently targets a single split peripheral and documents that limitation.

## Checks

- repository formatter
- full RMK feature-matrix tests
- Rynk host tests, doctests, WASM checks/package typecheck, and clippy