### PR TITLE
fix(keyboard): re-strike a shared HID usage so a roll types both keys

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1486,8 +1486,6 @@ impl<'a> Keyboard<'a> {
             return;
         }
 
-        // Count owners before and after, so what follows depends on what the
-        // registration actually did rather than on what it was expected to do.
         let owners_before = self.usage_owners(key);
 
         if event.pressed {
@@ -1496,9 +1494,8 @@ impl<'a> Keyboard<'a> {
             self.unregister_key(key, event);
         }
 
-        // A press that gives an already-held usage an additional owner needs a
-        // report without that usage before the ordinary one, or the host never
-        // sees the absent->present transition that produces a character.
+        // A press that adds another owner to a held usage needs one report without
+        // that usage first, or the host never sees the absent->present transition.
         if event.pressed && owners_before > 0 && self.usage_owners(key) > owners_before {
             self.send_keyboard_report_suppressing(event.pressed, key).await;
         }
@@ -1506,24 +1503,10 @@ impl<'a> Keyboard<'a> {
         self.send_keyboard_report_with_resolved_modifiers(event.pressed).await;
     }
 
-    /// How many report slots are holding `key`.
+    /// How many report slots hold `key`.
     ///
-    /// Two matrix positions can map to the same HID usage - `<` and `>` on a
-    /// board where `>` is the shifted form of `<`, or simply the same keycode
-    /// bound twice. Each gets its own slot, but the report collapses them to
-    /// one usage, so rolling from one to the other would otherwise leave the
-    /// usage continuously down and the second key would produce nothing.
-    ///
-    /// Comparing this count across the registration keys the decision on
-    /// ownership actually changing. Two positions bound to the same plain
-    /// keycode roll into two characters; a real modifier never enters
-    /// `held_keycodes` so it cannot re-strike anything; and a press that finds
-    /// no free slot registers nothing and so synthesises nothing, leaving the
-    /// established rollover behaviour alone.
-    ///
-    /// Counted over `held_keycodes` alone, because that is the array the
-    /// outgoing report is built from: this measures what the host is about to
-    /// see rather than a bookkeeping view of it.
+    /// Two matrix positions can map to one HID usage, and the report collapses
+    /// the duplicates, so only the slot count separates a re-strike from a hold.
     fn usage_owners(&self, key: HidKeyCode) -> usize {
         if key == HidKeyCode::No {
             return 0;
@@ -1905,24 +1888,13 @@ impl<'a> Keyboard<'a> {
     }
 
     /// Build the keyboard report for the current held keycodes with modifiers
-    /// resolved.
+    /// resolved, holding `suppressed` out of the keycode array.
     ///
     /// Multiple slots can hold the same HID usage, but the host only tracks
     /// each usage as up or down, so duplicates are collapsed to the first slot
     /// that holds them. This keeps the shared usage down until the last holder
-    /// releases it.
-    pub(crate) fn build_keyboard_report(&mut self, pressed: bool) -> KeyboardReport {
-        // `HidKeyCode::No` is never present in a report, so suppressing it is
-        // exactly the unmodified behaviour every existing caller relies on.
-        self.build_keyboard_report_suppressing(pressed, HidKeyCode::No)
-    }
-
-    /// `build_keyboard_report`, with one usage held out of the keycode array.
-    ///
-    /// Used once per re-strike to give the host the absent->present transition
-    /// a shared usage would otherwise never show. Every other held usage and
-    /// every held modifier stay present: this is not an all-clear report.
-    fn build_keyboard_report_suppressing(&mut self, pressed: bool, suppressed: HidKeyCode) -> KeyboardReport {
+    /// releases it. `HidKeyCode::No` suppresses nothing.
+    pub(crate) fn build_keyboard_report(&mut self, pressed: bool, suppressed: HidKeyCode) -> KeyboardReport {
         let modifiers = self.resolve_modifiers(pressed);
         info!(
             "Sending keyboard report, modifiers: {:?}, keycodes: {:?}",
@@ -1947,16 +1919,12 @@ impl<'a> Keyboard<'a> {
 
     /// Send the keyboard report with resolved modifiers to the host.
     pub(crate) async fn send_keyboard_report_with_resolved_modifiers(&mut self, pressed: bool) {
-        let report = self.build_keyboard_report(pressed);
-        self.send_report(Report::KeyboardReport(report)).await;
-
-        // Yield once after sending the report to channel
-        yield_now().await;
+        self.send_keyboard_report_suppressing(pressed, HidKeyCode::No).await;
     }
 
-    /// Send one report with `suppressed` held out, through the ordinary channel.
+    /// Send the keyboard report with `suppressed` held out of the keycode array.
     async fn send_keyboard_report_suppressing(&mut self, pressed: bool, suppressed: HidKeyCode) {
-        let report = self.build_keyboard_report_suppressing(pressed, suppressed);
+        let report = self.build_keyboard_report(pressed, suppressed);
         self.send_report(Report::KeyboardReport(report)).await;
 
         // Yield once after sending the report to channel

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1486,13 +1486,49 @@ impl<'a> Keyboard<'a> {
             return;
         }
 
+        // Count owners before and after, so what follows depends on what the
+        // registration actually did rather than on what it was expected to do.
+        let owners_before = self.usage_owners(key);
+
         if event.pressed {
             self.register_key(key, event);
         } else {
             self.unregister_key(key, event);
         }
 
+        // A press that gives an already-held usage an additional owner needs a
+        // report without that usage before the ordinary one, or the host never
+        // sees the absent->present transition that produces a character.
+        if event.pressed && owners_before > 0 && self.usage_owners(key) > owners_before {
+            self.send_keyboard_report_suppressing(event.pressed, key).await;
+        }
+
         self.send_keyboard_report_with_resolved_modifiers(event.pressed).await;
+    }
+
+    /// How many report slots are holding `key`.
+    ///
+    /// Two matrix positions can map to the same HID usage - `<` and `>` on a
+    /// board where `>` is the shifted form of `<`, or simply the same keycode
+    /// bound twice. Each gets its own slot, but the report collapses them to
+    /// one usage, so rolling from one to the other would otherwise leave the
+    /// usage continuously down and the second key would produce nothing.
+    ///
+    /// Comparing this count across the registration keys the decision on
+    /// ownership actually changing. Two positions bound to the same plain
+    /// keycode roll into two characters; a real modifier never enters
+    /// `held_keycodes` so it cannot re-strike anything; and a press that finds
+    /// no free slot registers nothing and so synthesises nothing, leaving the
+    /// established rollover behaviour alone.
+    ///
+    /// Counted over `held_keycodes` alone, because that is the array the
+    /// outgoing report is built from: this measures what the host is about to
+    /// see rather than a bookkeeping view of it.
+    fn usage_owners(&self, key: HidKeyCode) -> usize {
+        if key == HidKeyCode::No {
+            return 0;
+        }
+        self.held_keycodes.iter().filter(|&&held| held == key).count()
     }
 
     // Process action special keys
@@ -1876,6 +1912,17 @@ impl<'a> Keyboard<'a> {
     /// that holds them. This keeps the shared usage down until the last holder
     /// releases it.
     pub(crate) fn build_keyboard_report(&mut self, pressed: bool) -> KeyboardReport {
+        // `HidKeyCode::No` is never present in a report, so suppressing it is
+        // exactly the unmodified behaviour every existing caller relies on.
+        self.build_keyboard_report_suppressing(pressed, HidKeyCode::No)
+    }
+
+    /// `build_keyboard_report`, with one usage held out of the keycode array.
+    ///
+    /// Used once per re-strike to give the host the absent->present transition
+    /// a shared usage would otherwise never show. Every other held usage and
+    /// every held modifier stay present: this is not an all-clear report.
+    fn build_keyboard_report_suppressing(&mut self, pressed: bool, suppressed: HidKeyCode) -> KeyboardReport {
         let modifiers = self.resolve_modifiers(pressed);
         info!(
             "Sending keyboard report, modifiers: {:?}, keycodes: {:?}",
@@ -1885,7 +1932,7 @@ impl<'a> Keyboard<'a> {
         let mut n = 0;
         for k in self.held_keycodes {
             let code = k as u8;
-            if code != 0 && !keycodes[..n].contains(&code) {
+            if code != 0 && k != suppressed && !keycodes[..n].contains(&code) {
                 keycodes[n] = code;
                 n += 1;
             }
@@ -1901,6 +1948,15 @@ impl<'a> Keyboard<'a> {
     /// Send the keyboard report with resolved modifiers to the host.
     pub(crate) async fn send_keyboard_report_with_resolved_modifiers(&mut self, pressed: bool) {
         let report = self.build_keyboard_report(pressed);
+        self.send_report(Report::KeyboardReport(report)).await;
+
+        // Yield once after sending the report to channel
+        yield_now().await;
+    }
+
+    /// Send one report with `suppressed` held out, through the ordinary channel.
+    async fn send_keyboard_report_suppressing(&mut self, pressed: bool, suppressed: HidKeyCode) {
+        let report = self.build_keyboard_report_suppressing(pressed, suppressed);
         self.send_report(Report::KeyboardReport(report)).await;
 
         // Yield once after sending the report to channel

--- a/rmk/tests/scenarios/hid_reports.toml
+++ b/rmk/tests/scenarios/hid_reports.toml
@@ -54,9 +54,12 @@ steps = [
 ]
 expect = [{ mouse = { x = 5 } }, { mouse = { } }]
 
-# `]` and its `SHIFTED()` twin `}` share one HID usage. The report
-# deduplicates held keycodes so the shared usage stays down until the
-# last holder releases it; the second key no longer vanishes on a roll.
+# `]` and its `SHIFTED()` twin `}` share one HID usage. Two halves must hold
+# at once: the report deduplicates held keycodes so the usage stays down until
+# the last holder releases it, and a press that re-strikes a usage another
+# position already holds gets one report without it first, so the host sees the
+# absent->present transition that produces the second character. Pressing `}`
+# at (1,2) while (1,1) still holds `]` is that re-strike.
 [[test]]
 name = "shared_keycode_roll_keeps_second_key"
 steps = [
@@ -75,6 +78,7 @@ expect = [
   ["LShift", "Dot"],
   ["Dot", "RightBracket"],
   ["RightBracket"],
+  ["LShift"],
   ["LShift", "RightBracket"],
   ["LShift", "RightBracket"],
   ["LShift", "RightBracket", "Kc0"],

--- a/rmk/tests/scenarios/shared_usage_restrike.toml
+++ b/rmk/tests/scenarios/shared_usage_restrike.toml
@@ -2,21 +2,13 @@
 # twin `>`, or simply one keycode bound twice. Each press takes its own report
 # slot, but the report collapses held keycodes to one usage, so a roll from one
 # to the other leaves the usage continuously down and the host — which emits a
-# character on the absent→present transition — sees one keystroke for two.
-#
-# The usage must also stay down while any owner holds it, so the two halves have
-# to hold at once: exactly one extra report per re-strike, carrying every other
-# held usage and every held modifier.
+# character on the absent→present transition — sees one keystroke for two. The
+# usage must still stay down while any owner holds it, so the repair is one
+# extra report per re-strike, carrying every other held usage and modifier.
 #
 # Layer 0 row 0 pairs `<` with `>` and binds `Kc7` twice; row 1 is six distinct
 # keycodes to fill the report array; row 2 re-binds `Kc1` for the full-array
 # case and carries the two real modifiers.
-#
-# The decision is taken by comparing how many slots hold the usage on behalf of
-# a registered key event, before and after registration. That is an observation
-# of what registration did rather than a prediction of what it would do, so a
-# press finding no free slot synthesises nothing, and any path that gives the
-# usage a new owner strikes it however the slot came to hold it.
 
 [layout]
 rows = 3

--- a/rmk/tests/scenarios/shared_usage_restrike.toml
+++ b/rmk/tests/scenarios/shared_usage_restrike.toml
@@ -1,0 +1,293 @@
+# Two matrix positions can map to the same HID usage: `<` and its `SHIFTED()`
+# twin `>`, or simply one keycode bound twice. Each press takes its own report
+# slot, but the report collapses held keycodes to one usage, so a roll from one
+# to the other leaves the usage continuously down and the host — which emits a
+# character on the absent→present transition — sees one keystroke for two.
+#
+# The usage must also stay down while any owner holds it, so the two halves have
+# to hold at once: exactly one extra report per re-strike, carrying every other
+# held usage and every held modifier.
+#
+# Layer 0 row 0 pairs `<` with `>` and binds `Kc7` twice; row 1 is six distinct
+# keycodes to fill the report array; row 2 re-binds `Kc1` for the full-array
+# case and carries the two real modifiers.
+#
+# The decision is taken by comparing how many slots hold the usage on behalf of
+# a registered key event, before and after registration. That is an observation
+# of what registration did rather than a prediction of what it would do, so a
+# press finding no free slot synthesises nothing, and any path that gives the
+# usage a new owner strikes it however the slot came to hold it.
+
+[layout]
+rows = 3
+cols = 6
+map = """
+(0,0)  (0,1)  (0,2)  (0,3)  (0,4)  (0,5)
+(1,0)  (1,1)  (1,2)  (1,3)  (1,4)  (1,5)
+(2,0)  (2,1)  (2,2)  (2,3)  (2,4)  (2,5)
+"""
+
+[[keymap.layer]]
+keys = """
+NonusBackslash  SHIFTED(NonusBackslash)  Kc7  Kc7  No      No
+Kc1             Kc2                      Kc3  Kc4  Kc5     Kc6
+Kc1             No                       No   No   LShift  RShift
+"""
+
+# The report in #809: `<` rolled into `>` must type both. On the unmodified
+# base the second press only adds a modifier to a usage already down, so the
+# host receives one `<` and no `>`.
+[[test]]
+name = "rolled_shared_usage_types_both_keys"
+steps = [
+  { press = [0, 0] },   # <
+  { press = [0, 1] },   # > while < is still held
+  { release = [0, 0] },
+  { release = [0, 1] },
+]
+expect = [
+  ["NonusBackslash"],
+  ["LShift"],
+  ["LShift", "NonusBackslash"],
+  ["LShift", "NonusBackslash"],
+  [],
+]
+
+# The same roll with no modifier anywhere: one keycode bound at two positions.
+# Detection keys on which position owns the slot, not on the modifier set.
+[[test]]
+name = "rolled_same_keycode_two_positions_types_twice"
+steps = [
+  { press = [0, 2] },
+  { press = [0, 3] },
+  { release = [0, 2] },
+  { release = [0, 3] },
+]
+expect = [
+  ["Kc7"],
+  [],
+  ["Kc7"],
+  ["Kc7"],
+  [],
+]
+
+# Press `>` first and roll back to `<`. The re-strike is symmetric.
+[[test]]
+name = "reverse_roll_shifted_first"
+steps = [
+  { press = [0, 1] },   # >
+  { press = [0, 0] },   # <
+  { release = [0, 1] },
+  { release = [0, 0] },
+]
+expect = [
+  ["LShift", "NonusBackslash"],
+  [],
+  ["NonusBackslash"],
+  ["NonusBackslash"],
+  [],
+]
+
+# Holding a usage and tapping a real Shift is one activation plus an
+# independent modifier, not two activations. No transition report.
+[[test]]
+name = "held_key_plus_tapped_real_shift_types_once"
+steps = [
+  { press = [0, 0] },
+  { press = [2, 4] },   # real LShift
+  { release = [2, 4] },
+  { release = [0, 0] },
+]
+expect = [
+  ["NonusBackslash"],
+  ["LShift", "NonusBackslash"],
+  ["NonusBackslash"],
+  [],
+]
+
+# A second modifier arriving and leaving while a usage is held changes the
+# modifier byte and nothing else.
+[[test]]
+name = "modifier_only_change_sends_no_transition"
+steps = [
+  { press = [0, 0] },
+  { press = [2, 4] },   # LShift
+  { press = [2, 5] },   # RShift
+  { release = [2, 5] },
+  { release = [2, 4] },
+  { release = [0, 0] },
+]
+expect = [
+  ["NonusBackslash"],
+  ["LShift", "NonusBackslash"],
+  ["LShift", "RShift", "NonusBackslash"],
+  ["LShift", "NonusBackslash"],
+  ["NonusBackslash"],
+  [],
+]
+
+# The half this must not break: with two owners holding one usage, releasing
+# the first keeps it down, and releasing the last clears it. Both orders.
+[[test]]
+name = "shared_usage_survives_first_release"
+steps = [
+  { press = [0, 2] },
+  { press = [0, 3] },
+  { release = [0, 3] },   # release the second owner first
+  { release = [0, 2] },
+]
+expect = [
+  ["Kc7"],
+  [],
+  ["Kc7"],
+  ["Kc7"],
+  [],
+]
+
+# The transition report clears only the re-struck usage. Everything else that
+# is down stays down.
+[[test]]
+name = "transition_preserves_other_held_keys"
+steps = [
+  { press = [1, 0] },   # Kc1
+  { press = [1, 1] },   # Kc2
+  { press = [0, 0] },   # <
+  { press = [0, 1] },   # >
+  { release = [0, 1] },
+  { release = [0, 0] },
+  { release = [1, 1] },
+  { release = [1, 0] },
+]
+expect = [
+  ["Kc1"],
+  ["Kc1", "Kc2"],
+  ["Kc1", "Kc2", "NonusBackslash"],
+  ["LShift", "Kc1", "Kc2"],
+  ["LShift", "Kc1", "Kc2", "NonusBackslash"],
+  # `>` carried the shift, so releasing it takes the modifier with it while
+  # `<` keeps the usage down. Both halves of that are unchanged here.
+  ["Kc1", "Kc2", "NonusBackslash"],
+  ["Kc1", "Kc2"],
+  ["Kc1"],
+  [],
+]
+
+# A physically held modifier is present in every report, the transition
+# included. Dropping it there would break a chorded shortcut.
+[[test]]
+name = "transition_preserves_held_modifiers"
+steps = [
+  { press = [2, 5] },   # RShift, physically held throughout
+  { press = [0, 2] },
+  { press = [0, 3] },
+  { release = [0, 3] },
+  { release = [0, 2] },
+  { release = [2, 5] },
+]
+expect = [
+  ["RShift"],
+  ["RShift", "Kc7"],
+  ["RShift"],
+  ["RShift", "Kc7"],
+  ["RShift", "Kc7"],
+  ["RShift"],
+  [],
+]
+
+# The already-correct stream from the report: press and release each key fully
+# and nothing changes. Three makes, three characters, no extra reports.
+[[test]]
+name = "sequential_typing_is_unchanged"
+steps = [
+  { press = [0, 0] },
+  { release = [0, 0] },
+  { press = [0, 1] },
+  { release = [0, 1] },
+  { press = [0, 0] },
+  { release = [0, 0] },
+]
+expect = [
+  ["NonusBackslash"],
+  [],
+  ["LShift", "NonusBackslash"],
+  [],
+  ["NonusBackslash"],
+  [],
+]
+
+# One key held sends exactly one make and one break, so host auto-repeat is
+# not chopped by a spurious lift.
+[[test]]
+name = "held_key_sends_no_extra_reports"
+steps = [
+  { press = [0, 0] },
+  { delay = 200 },
+  { release = [0, 0] },
+]
+expect = [
+  ["NonusBackslash"],
+  [],
+]
+
+# With the six-key array full a seventh press registers nothing, so it gains no
+# ownership and must synthesise nothing: the usage was already down and stays
+# down, exactly as it does on any other over-capacity press. Releasing the
+# original owner then clears it while the seventh key is still physically held,
+# which is this firmware's established rollover behaviour and is unchanged here.
+[[test]]
+name = "an_unregistered_seventh_press_synthesises_no_stroke"
+steps = [
+  { press = [1, 0] },   # Kc1
+  { press = [1, 1] },   # Kc2
+  { press = [1, 2] },   # Kc3
+  { press = [1, 3] },   # Kc4
+  { press = [1, 4] },   # Kc5
+  { press = [1, 5] },   # Kc6 - six owners, array full
+  { press = [2, 0] },   # Kc1 again: no free slot, so no new owner
+  { release = [1, 0] },
+  { release = [2, 0] },
+  { release = [1, 5] },
+  { release = [1, 4] },
+  { release = [1, 3] },
+  { release = [1, 2] },
+  { release = [1, 1] },
+]
+expect = [
+  ["Kc1"],
+  ["Kc1", "Kc2"],
+  ["Kc1", "Kc2", "Kc3"],
+  ["Kc1", "Kc2", "Kc3", "Kc4"],
+  ["Kc1", "Kc2", "Kc3", "Kc4", "Kc5"],
+  ["Kc1", "Kc2", "Kc3", "Kc4", "Kc5", "Kc6"],
+  ["Kc1", "Kc2", "Kc3", "Kc4", "Kc5", "Kc6"],
+  ["Kc2", "Kc3", "Kc4", "Kc5", "Kc6"],
+  ["Kc2", "Kc3", "Kc4", "Kc5", "Kc6"],
+  ["Kc2", "Kc3", "Kc4", "Kc5"],
+  ["Kc2", "Kc3", "Kc4"],
+  ["Kc2", "Kc3"],
+  ["Kc2"],
+  [],
+]
+
+# The plain-keycode pair with an unrelated usage held across the roll: the
+# transition drops only the re-struck usage, with no modifier anywhere in the
+# stream to make it look like a shift artefact.
+[[test]]
+name = "plain_keycode_restrike_preserves_an_unrelated_held_key"
+steps = [
+  { press = [0, 2] },   # Kc7 at one position
+  { press = [1, 0] },   # Kc1 at another
+  { press = [0, 3] },   # Kc7 again from a third position
+  { release = [0, 3] },
+  { release = [1, 0] },
+  { release = [0, 2] },
+]
+expect = [
+  ["Kc7"],
+  ["Kc7", "Kc1"],
+  ["Kc1"],
+  ["Kc7", "Kc1"],
+  ["Kc7", "Kc1"],
+  ["Kc7"],
+  [],
+]


### PR DESCRIPTION
Closes #809.

## The defect

Two matrix positions can map to the same HID usage. On the reporter's board `<`
is `KC_NONUS_BSLASH` and `>` is `LSFT(KC_NONUS_BSLASH)` — different keys, one
usage, differing only by the shift modifier.

State tracking is already right. `register_keycode` gives each position its own
report slot, so `held_keycodes` holds `NonusBackslash` twice with two distinct
owners. The report is where they merge (`keyboard.rs:1886`):

```rust
for k in self.held_keycodes {
    let code = k as u8;
    if code != 0 && !keycodes[..n].contains(&code) {
```

A USB HID host emits a character on the transition of a usage from absent to
present in the keycode array. A usage that is already present and merely gains
a modifier produces nothing. So rolling `<` into `>` sends:

```
["NonusBackslash"]
["LShift","NonusBackslash"]
["LShift","NonusBackslash"]
[]
```

One make for two intended keystrokes. Roll `<` into `>` and type `<` again and
the host receives `<` `<`, which is the `<<` in the report.

## Why the obvious repair is not available

The deduplication is deliberate. `fix(keyboard): deduplicate held keycodes in
the keyboard report` added it along with
`hid_reports::shared_keycode_roll_keeps_second_key`, whose comment states the
intent: the shared usage stays down until the last holder releases it. Before
that, releasing the *first* of two owners cleared a usage the second owner still
held — a dropped key.

These are two halves of one problem. Removing the deduplication brings back the
dropped key; keeping only the deduplication keeps the lost character. Both have
to hold at once.

## The change

A press that gives an already-held usage an **additional owner** now sends one
extra report first: the ordinary report with only that usage suppressed. The
normal report follows, so the host observes a fresh absent→present transition.

Everything else stays. The suppressed report keeps every other held usage and
every held modifier — it is never an all-clear report — and the usage still
remains down until the last owner releases it.

The decision comes from counting how many report slots hold that usage on
behalf of a registered key event, immediately before and immediately after
registration. That is an observation of what registration did rather than a
prediction of what it would do, which matters in three places:

- a real modifier never enters `held_keycodes`, so it can never re-strike a
  usage — holding a key and tapping `Shift` is one activation plus an
  independent modifier;
- two positions bound to the same plain keycode gain an owner just as a
  `SHIFTED()` pair does, so they roll into two characters too;
- a press that finds no free slot registers nothing and so gains no owner. It
  synthesises nothing and follows the existing rollover behaviour, rather than
  emitting a stroke for a key the report cannot track.

`build_keyboard_report` accepts the usage to suppress. The ordinary send path
passes `HidKeyCode::No`, which suppresses nothing, while a re-strike passes the
shared usage. Both paths use `send_keyboard_report_suppressing` and the existing
`send_report` transport. No
allocation, no feature gate, no new configuration, no change to
`KeyboardReport`'s shape or the six-key array.

One extra report per re-strike is the intended cost. No other report count
changes.

## Tests

`rmk/tests/scenarios/shared_usage_restrike.toml`, twelve cases, plus
`shared_keycode_roll_keeps_second_key` updated rather than replaced — its
subject, that the usage stays down while an owner holds it, is exactly the half
this must preserve, so only the new transition report is inserted into its
expectations and its comment now states both halves.

On this branch all five `RMK_TEST_FEATURESETS` rows pass:

| features | tests |
| --- | ---: |
| *(none)* | 453 passed |
| `vial,host_lock,_no_usb,steno,passkey_entry` | 520 passed |
| `rynk,_ble,split,async_matrix,storage` | 569 passed |
| `dongle,_ble,storage` | 492 passed |
| `dongle,vial,_ble,storage` | 520 passed |

On unmodified `main` with the same test files, the `rynk,_ble,split,…` row
gives **561 passed, 8 failed**. The eight are the ones that assert the new
transition:

`shared_keycode_roll_keeps_second_key`, `rolled_shared_usage_types_both_keys`,
`reverse_roll_shifted_first`, `rolled_same_keycode_two_positions_types_twice`,
`shared_usage_survives_first_release`, `transition_preserves_other_held_keys`,
`transition_preserves_held_modifiers`,
`plain_keycode_restrike_preserves_an_unrelated_held_key`.

The rest pass on `main` too, and they are what keeps the change honest rather
than just proving the symptom: each names a case where a stroke must *not* be
synthesised, so a rule that fired too eagerly would break them.

- `held_key_plus_tapped_real_shift_types_once` and
  `modifier_only_change_sends_no_transition` — a modifier arriving or leaving
  while a usage is held changes the modifier byte and nothing else;
- `sequential_typing_is_unchanged` — the already-correct `<` `>` `<` stream from
  the report is byte-identical after the change;
- `held_key_sends_no_extra_reports` — one key held sends exactly one make and
  one break, so host auto-repeat is not chopped;
- `an_unregistered_seventh_press_synthesises_no_stroke` — with the six-key array
  full, a seventh press mapped to a held usage registers nothing, gains no
  owner, and emits no extra report.

They do not cover every possible false positive; they cover those four classes.

`cargo fmt --all -- --check` on nightly and
`cargo clippy … --all-targets -- -D warnings` are both clean.

## A limit of this validation

The transition report and the make that follows are two consecutive reports,
intended to become two interrupt transfers over USB or two notifications over
BLE HID. A link that coalesced or dropped one would hide the make again.

The scenario harness asserts the report **stream**, so it proves the firmware
emits both. It does not observe an actual transfer on either transport, so it
proves nothing about delivery over USB or BLE, and I have not tested that on
hardware.
