### PR TITLE
docs(site): list accepted-but-unimplemented key names (v0.9)

### DIFF
--- a/docs/docs/main/docs/configuration/keymap_configuration/keycodes.md
+++ b/docs/docs/main/docs/configuration/keymap_configuration/keycodes.md
@@ -299,6 +299,14 @@ For simple keycodes with shift active you can use `SHIFTED(key)` in your [layout
 | `ComboToggle`    |         | Toggle combos                                                         |
 | `CapsWordToggle` |         | Toggle [Caps Word](./special_keys#caps-word)                          |
 
+## Not yet implemented keys
+
+The following key names are accepted in `keyboard.toml` but not implemented yet — pressing them does nothing:
+
+- `DebugToggle`, `OutputAuto`, `OutputUsb`, `OutputBluetooth`
+- Backlight keys: `BacklightOn`, `BacklightOff`, `BacklightToggle`, `BacklightDown`, `BacklightUp`, `BacklightStep`, `BacklightToggleBreathing`
+- RGB keys: `RgbTog`, `RgbHui`, `RgbHud`, `RgbSai`, `RgbSad`, `RgbVai`, `RgbVad`, `RgbSpi`, `RgbSpd`, and the `RgbMode*` effect names
+
 ## User keys
 
 | Keycode          | Aliases   | Usage                                                                                                                                                                                                                |


### PR DESCRIPTION
Backport of the docs-site change from #1103 to the v0.9 docs branch.

Adds a "Not yet implemented keys" section to the keycodes page: `keyboard.toml` accepts every `KeyboardAction`/`LightAction` variant name (`DebugToggle`, `OutputAuto`/`OutputUsb`/`OutputBluetooth`, all backlight/RGB actions), but they are no-ops in the v0.9 firmware — pressing them does nothing.

The page content was identical between `main` and `docs/v0.9`, so this is a clean cherry-pick of the site commit only (no Rust source changes; this branch only feeds the docs site).