### PR TITLE
usb: honour SET_PROTOCOL on the boot-subclass keyboard interface

### DIFF
--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix UTF-8 panics when non-ASCII names are used in `keyboard.toml` aliases, and accept Unicode whitespace between keymap actions
+- Honour `SET_PROTOCOL` on the boot-subclass keyboard interface. v0.9.0 advertises the boot keyboard protocol in the descriptor, but the device rejected the switch to boot mode and `GET_PROTOCOL` always answered report mode, so a host that requires the switch before using the keyboard — a BIOS/UEFI setup screen, a KVM switch, a BMC — could be left without a working keyboard. The keyboard interface now accepts both modes and reports the selected one
 
 ## [0.9.0] - 2026-08-27
 

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -3,7 +3,7 @@ use embassy_futures::select::{Either, select};
 use embassy_sync::signal::Signal;
 #[cfg(feature = "usb_log")]
 use embassy_usb::class::cdc_acm::CdcAcmClass;
-use embassy_usb::class::hid::{HidReader, HidReaderWriter, HidWriter, ReportId, RequestHandler};
+use embassy_usb::class::hid::{HidProtocolMode, HidReader, HidReaderWriter, HidWriter, ReportId, RequestHandler};
 use embassy_usb::control::OutResponse;
 use embassy_usb::driver::{Driver, EndpointError};
 use embassy_usb::{Builder, Handler, UsbDevice};
@@ -553,7 +553,11 @@ macro_rules! usb_hid_state_and_config {
         }
 
         let state = paste::paste! { [<$descriptor:snake:upper _STATE>].init(::embassy_usb::class::hid::State::new()) };
-        let request_handler = paste::paste! { [<$descriptor:snake:upper _HANDLER>].init($crate::usb::UsbRequestHandler {}) };
+        let request_handler = paste::paste! {
+            [<$descriptor:snake:upper _HANDLER>].init($crate::usb::UsbRequestHandler {
+                protocol: ::embassy_usb::class::hid::HidProtocolMode::Report,
+            })
+        };
 
         let hid_config = ::embassy_usb::class::hid::Config {
             report_descriptor: <$descriptor>::desc(),
@@ -604,11 +608,26 @@ pub(crate) use add_usb_reader_writer;
 pub(crate) use add_usb_writer;
 pub(crate) use usb_hid_state_and_config;
 
-pub(crate) struct UsbRequestHandler {}
+pub(crate) struct UsbRequestHandler {
+    pub(crate) protocol: HidProtocolMode,
+}
 
 impl RequestHandler for UsbRequestHandler {
     fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
         info!("Set report for {:?}: {:?}", id, data);
+        OutResponse::Accepted
+    }
+
+    fn get_protocol(&self) -> HidProtocolMode {
+        self.protocol
+    }
+
+    fn set_protocol(&mut self, protocol: HidProtocolMode) -> OutResponse {
+        // KeyboardReport is already the 8-byte boot keyboard layout, so the
+        // mode only changes what GET_PROTOCOL answers.
+        // TODO: Return to Report on a bus reset once embassy-usb tells the
+        // request handler about it (embassy-rs/embassy#6891).
+        self.protocol = protocol;
         OutResponse::Accepted
     }
 }
@@ -702,10 +721,28 @@ impl Handler for UsbDeviceHandler {
 #[cfg(test)]
 mod tests {
     use embassy_usb::Handler;
+    use embassy_usb::class::hid::RequestHandler;
     use rmk_types::connection::UsbState;
 
-    use super::UsbDeviceHandler;
+    use super::{HidProtocolMode, OutResponse, UsbDeviceHandler, UsbRequestHandler};
     use crate::state::{current_usb_state, set_usb_state};
+
+    /// A BIOS or KVM switch selects the boot protocol before it will use the
+    /// keyboard; rejecting the switch strands a host that trusts the boot
+    /// subclass the interface advertises.
+    #[test]
+    fn the_keyboard_switches_protocol_and_reports_it() {
+        let mut handler = UsbRequestHandler {
+            protocol: HidProtocolMode::Report,
+        };
+        assert_eq!(handler.get_protocol(), HidProtocolMode::Report);
+
+        assert_eq!(handler.set_protocol(HidProtocolMode::Boot), OutResponse::Accepted);
+        assert_eq!(handler.get_protocol(), HidProtocolMode::Boot);
+
+        assert_eq!(handler.set_protocol(HidProtocolMode::Report), OutResponse::Accepted);
+        assert_eq!(handler.get_protocol(), HidProtocolMode::Report);
+    }
 
     /// A charge-only cable / wall charger enables the device (VBUS present) but
     /// never enumerates it; the bus-idle suspend that follows must not publish


### PR DESCRIPTION
### Summary

The keyboard interface is declared with `HidSubclass::Boot` and `HidBootProtocol::Keyboard` — v0.9.0 added this as *"Advertise the boot keyboard protocol on the primary HID interface, so the keyboard works in BIOS/UEFI and other boot-protocol-only hosts"*. But `UsbRequestHandler` does not override `set_protocol`, so embassy-usb's default implementation rejects `SET_PROTOCOL(Boot)` and `GET_PROTOCOL` always answers report mode.

The descriptor therefore advertises boot support that the device refuses to enter. A host that requires the switch before it will use the keyboard — a BIOS or UEFI setup screen, a KVM switch, a BMC — can be left without a working keyboard, while hosts that parse the report descriptor keep working, so the failure only shows up on some setups. This completes the request-handler side of the boot-protocol support advertised in v0.9.0.

### What this changes

`UsbRequestHandler` keeps the selected mode as a field and answers `SET_PROTOCOL` / `GET_PROTOCOL` from it.

Nothing changes about what the interface transmits: `KeyboardReport` is already the boot keyboard layout from HID 1.11 Appendix B — one modifier byte, one reserved byte and six keycodes, with no report ID — so the same report is valid in either protocol mode. The mode only changes what `GET_PROTOCOL` answers.

Two consequences worth stating plainly:

- The same handler type serves every HID interface, so the composite, steno and Vial interfaces now store and report the mode as well, instead of rejecting `SET_PROTOCOL(Boot)` through embassy-usb's default. HID 1.11 §7.2.5 and §7.2.6 define these requests for devices in the boot subclass, so hosts do not send them to those interfaces; carrying a per-interface flag just to keep rejecting them is more state than this fix needs.
- The mode is not restored to the report protocol on a USB bus reset. embassy-usb's `RequestHandler` gets no reset callback — I opened [embassy-rs/embassy#6891](https://github.com/embassy-rs/embassy/issues/6891) about adding one, and the `TODO` in the code points at it. A host is expected to set the protocol again when it reconfigures the keyboard (HID 1.11 §7.2.6 and Appendix F.4), so what remains after a reset is a stale `GET_PROTOCOL` answer until it does.

### Testing

**Unit tests.** `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` → 502 passed. `bash scripts/test_all.sh` → all rows pass. `bash scripts/format_all.sh` leaves no diff. Removing the store in `set_protocol` makes the new test fail, so it covers the behaviour it claims to.

**On hardware.** An earlier revision of this change was verified on an RP2040 keyboard against a Linux host, issuing the control transfers directly with pyusb. Both firmwares expose the same HID interfaces `[(0, 1, 1), (1, 0, 0), (2, 0, 0)]` — if0 declares boot/keyboard in both:

| | before | after |
|---|---|---|
| `SET_PROTOCOL(Boot)` | **STALL** | accepted |
| `GET_PROTOCOL` after that | Report | Boot |

That revision answered the requests from the device-level `Handler` and also restored report mode on a bus reset. The current revision answers them from the HID class's request handler and drops the reset restore, so it has **not** been re-run on hardware. The change was cherry-picked onto our production tree for that test — same code, different base — and typing was unaffected afterwards. I have **not** tested against an actual BIOS/UEFI, KVM or BMC: the hardware evidence here is the control-transfer behaviour, not end-to-end use on a boot-only host.

### Known gaps, unchanged by this PR

`GET_REPORT`, `SET_IDLE`/`GET_IDLE` and idle-rate retransmission are still unimplemented, and the control-pipe `SET_REPORT(Output)` is accepted without driving the LEDs (LED state comes from the interrupt OUT endpoint). Happy to follow up on those separately if you would like them covered.