### PR TITLE
Refactor: unified deadline when processing keyboard events

### DIFF
--- a/rmk/src/ble/profile.rs
+++ b/rmk/src/ble/profile.rs
@@ -81,6 +81,7 @@ impl Default for ProfileInfo {
 }
 
 /// BLE profile switch action
+#[derive(Debug)]
 pub(crate) enum BleProfileAction {
     Switch(u8),
     Previous,

--- a/rmk/src/channel.rs
+++ b/rmk/src/channel.rs
@@ -107,6 +107,16 @@ pub async fn drain_flash_channel_for_test() {
 #[cfg(feature = "_ble")]
 pub(crate) static BLE_PROFILE_CHANNEL: Channel<RawMutex, BleProfileAction, 1> = Channel::new();
 
+/// Test-only stand-in for the BLE profile task: hands each action's `Debug`
+/// form to `sink`, so a test can assert what a profile-key gesture sent.
+#[cfg(all(feature = "std", feature = "_ble"))]
+#[doc(hidden)]
+pub async fn drain_ble_profile_channel_for_test(mut sink: impl FnMut(std::string::String)) {
+    loop {
+        sink(std::format!("{:?}", BLE_PROFILE_CHANNEL.receive().await));
+    }
+}
+
 /// Vial RX from BLE GATT `output_data` writes — one 32-byte chunk per write.
 /// Pushed by `gatt_events_task`, drained by [`crate::ble::host::HostGattHandler::run`].
 #[cfg(all(feature = "vial", feature = "_ble"))]

--- a/rmk/src/channel.rs
+++ b/rmk/src/channel.rs
@@ -107,13 +107,19 @@ pub async fn drain_flash_channel_for_test() {
 #[cfg(feature = "_ble")]
 pub(crate) static BLE_PROFILE_CHANNEL: Channel<RawMutex, BleProfileAction, 1> = Channel::new();
 
-/// Test-only stand-in for the BLE profile task: hands each action's `Debug`
-/// form to `sink`, so a test can assert what a profile-key gesture sent.
-#[cfg(all(feature = "std", feature = "_ble"))]
+/// Test-only stand-in for the BLE profile task: records the `Debug` form of every
+/// received action in `sink`, so a test can check what a profile-key gesture sent.
+#[cfg(feature = "std")]
 #[doc(hidden)]
-pub async fn drain_ble_profile_channel_for_test(mut sink: impl FnMut(std::string::String)) {
+pub async fn drain_ble_profile_channel_for_test(sink: &mut std::vec::Vec<std::string::String>) {
+    #[cfg(feature = "_ble")]
     loop {
-        sink(std::format!("{:?}", BLE_PROFILE_CHANNEL.receive().await));
+        sink.push(std::format!("{:?}", BLE_PROFILE_CHANNEL.receive().await));
+    }
+    #[cfg(not(feature = "_ble"))]
+    {
+        let _ = sink;
+        core::future::pending::<()>().await
     }
 }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1,7 +1,5 @@
 use core::fmt::Debug;
 
-#[cfg(feature = "_ble")]
-use embassy_futures::select::{Either, select};
 use embassy_futures::yield_now;
 #[cfg(feature = "_ble")]
 use embassy_sync::signal::Signal;
@@ -142,29 +140,18 @@ impl Runnable for Keyboard<'_> {
     /// The report is sent using `send_report`.
     async fn run(&mut self) -> ! {
         loop {
-            // TODO: Now the unprocessed_events is only used in held_for_5s.
-            // Maybe it can be removed in the future?
-            if !self.unprocessed_events.is_empty() {
-                // Process unprocessed events
-                let e = self.unprocessed_events.remove(0);
-                debug!("Unprocessed event: {:?}", e);
-                self.process_inner(e).await
-            } else {
-                // Race the subscriber against the earliest pending deadline.
-                // `with_deadline` polls the subscriber first, so a queued event
-                // always wins over an already-expired deadline.
-                let event = match self.next_deadline() {
-                    Some(deadline) => {
-                        with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure())
-                            .await
-                            .ok()
-                    }
-                    None => Some(self.keyboard_event_subscriber.next_message_pure().await),
-                };
-                match event {
-                    Some(event) => self.process_inner(event).await,
-                    None => self.fire_expired().await,
-                }
+            // Race the subscriber against the earliest pending deadline.
+            // `with_deadline` polls the subscriber first, so a queued event
+            // always wins over an already-expired deadline.
+            let event = match self.next_deadline() {
+                Some(deadline) => with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure())
+                    .await
+                    .ok(),
+                None => Some(self.keyboard_event_subscriber.next_message_pure().await),
+            };
+            match event {
+                Some(event) => self.process_inner(event).await,
+                None => self.fire_expired().await,
             }
 
             // Run any macros triggered while handling the event.
@@ -189,9 +176,6 @@ pub struct Keyboard<'a> {
         { crate::KEYBOARD_EVENT_PUB_SIZE },
     >,
 
-    /// Unprocessed events
-    pub unprocessed_events: Vec<KeyboardEvent, 4>,
-
     /// Buffered held keys
     pub held_buffer: HeldBuffer,
 
@@ -214,6 +198,12 @@ pub struct Keyboard<'a> {
 
     /// Expiry deadline while the oneshot modifiers are armed (`Single`)
     osm_deadline: Option<Instant>,
+
+    /// In-progress User-key hold gesture (5s bond-clear etc.): the expiry
+    /// deadline and the held key's user id. Any key event disarms it; only
+    /// true idle for the full window completes the gesture.
+    #[cfg(feature = "_ble")]
+    user_hold: Option<(Instant, u8)>,
 
     /// Caps Word state machine
     caps_word: CapsWordState,
@@ -270,13 +260,14 @@ impl<'a> Keyboard<'a> {
             osl_deadline: None,
             osm_state: OneShotState::default(),
             osm_deadline: None,
+            #[cfg(feature = "_ble")]
+            user_hold: None,
             caps_word: CapsWordState::default(),
             with_modifiers: ModifierCombination::default(),
             macro_texting: false,
             macro_caps: false,
             fork_states: [None; FORK_MAX_NUM],
             fork_keep_mask: ModifierCombination::default(),
-            unprocessed_events: Vec::new(),
             held_buffer: HeldBuffer::new(),
             registered_keys: [None; 6],
             held_modifiers: ModifierCombination::default(),
@@ -324,6 +315,8 @@ impl<'a> Keyboard<'a> {
         [
             self.osm_deadline,
             self.osl_deadline,
+            #[cfg(feature = "_ble")]
+            self.user_hold.map(|(at, _)| at),
             self.next_buffered_key().map(|k| k.timeout_time),
             self.mouse.next_deadline(),
         ]
@@ -336,6 +329,8 @@ impl<'a> Keyboard<'a> {
     /// call before expiry is a no-op.
     async fn fire_expired(&mut self) {
         self.fire_oneshot_timeout().await;
+        #[cfg(feature = "_ble")]
+        self.fire_user_hold().await;
         self.fire_buffered_key_timeout().await;
         self.fire_mouse_repeat().await;
     }
@@ -360,6 +355,13 @@ impl<'a> Keyboard<'a> {
 
     /// Process key changes at (row, col)
     pub async fn process_inner(&mut self, event: KeyboardEvent) {
+        // Any key event cancels a pending User-key hold gesture; only true
+        // idle for the full window completes it.
+        #[cfg(feature = "_ble")]
+        {
+            self.user_hold = None;
+        }
+
         // Check for mode transitions (e.g., entering/exiting passkey entry)
         #[cfg(feature = "passkey_entry")]
         self.passkey_entry_state.check_mode_transition();
@@ -1668,25 +1670,9 @@ impl<'a> Keyboard<'a> {
         }
     }
 
-    /// True when the key is still down 5s later. A release inside the window is
-    /// pushed back to `unprocessed_events`, so it replays as a short press.
+    /// How long a User key must stay held to trigger its hold gesture.
     #[cfg(feature = "_ble")]
-    async fn held_for_5s(&mut self) -> bool {
-        match select(
-            embassy_time::Timer::after_millis(5000),
-            self.keyboard_event_subscriber.next_message_pure(),
-        )
-        .await
-        {
-            Either::First(_) => true,
-            Either::Second(e) => {
-                if self.unprocessed_events.push(e).is_err() {
-                    warn!("Unprocessed event queue is full, dropping event");
-                }
-                false
-            }
-        }
-    }
+    const USER_HOLD_DURATION: Duration = Duration::from_secs(5);
 
     async fn process_user(&mut self, id: u8, event: KeyboardEvent) {
         debug!("Processing user key id: {:?}, event: {:?}", id, event);
@@ -1698,28 +1684,18 @@ impl<'a> Keyboard<'a> {
             use crate::channel::BLE_PROFILE_CHANNEL;
             if event.pressed {
                 // The uniform gesture across all bond slots: tap switches, a 5s
-                // hold forgets the slot's bond and re-pairs. Holding a profile key
-                // clears that profile and switches to it, so it advertises openly.
-                if id < NUM_BLE_PROFILE as u8 && self.held_for_5s().await {
-                    info!("Profile key held: clearing bond on profile {}", id);
-                    BLE_PROFILE_CHANNEL.send(BleProfileAction::ClearSlot(id)).await;
-                    BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(id)).await;
-                }
-                // A 5s hold of the dongle key clears the local dongle bond and goes
-                // seeking, which is how a keyboard moves to a different dongle.
-                #[cfg(feature = "dongle")]
-                if id == NUM_BLE_PROFILE as u8 + 5 && self.held_for_5s().await {
-                    use crate::ble::profile::DONGLE_PROFILE;
-                    info!("Dongle key held: clearing dongle bond, seeking a dongle");
-                    BLE_PROFILE_CHANNEL
-                        .send(BleProfileAction::ClearSlot(DONGLE_PROFILE))
-                        .await;
-                    BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(DONGLE_PROFILE)).await;
-                }
+                // hold forgets the slot's bond and re-pairs (holding a profile key
+                // clears that profile and switches to it, so it advertises openly;
+                // the dongle key seeks a new dongle; the peer key clears the split
+                // peer). The hold is deadline-driven from `run()`: arming returns
+                // immediately, so the task keeps servicing events while it's down.
+                let arm = id < NUM_BLE_PROFILE as u8;
                 #[cfg(feature = "split")]
-                if id == NUM_BLE_PROFILE as u8 + 4 && self.held_for_5s().await {
-                    publish_event(ClearPeerEvent);
-                    info!("Clear peer");
+                let arm = arm || id == NUM_BLE_PROFILE as u8 + 4;
+                #[cfg(feature = "dongle")]
+                let arm = arm || id == NUM_BLE_PROFILE as u8 + 5;
+                if arm {
+                    self.user_hold = Some((Instant::now() + Self::USER_HOLD_DURATION, id));
                 }
             } else {
                 // Other user keys are processed when released.
@@ -1754,6 +1730,41 @@ impl<'a> Keyboard<'a> {
                         .await;
                 }
             }
+        }
+    }
+
+    /// Fire an expired User-key hold gesture: clear the bond of the held slot
+    /// and switch to it (or clear the split peer). Reaching expiry implies no
+    /// key event intervened, since any event disarms the gesture.
+    #[cfg(feature = "_ble")]
+    async fn fire_user_hold(&mut self) {
+        let Some((deadline, id)) = self.user_hold else { return };
+        if Instant::now() < deadline {
+            return;
+        }
+        self.user_hold = None;
+
+        use crate::NUM_BLE_PROFILE;
+        use crate::ble::profile::BleProfileAction;
+        use crate::channel::BLE_PROFILE_CHANNEL;
+        if id < NUM_BLE_PROFILE as u8 {
+            info!("Profile key held: clearing bond on profile {}", id);
+            BLE_PROFILE_CHANNEL.send(BleProfileAction::ClearSlot(id)).await;
+            BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(id)).await;
+        }
+        #[cfg(feature = "split")]
+        if id == NUM_BLE_PROFILE as u8 + 4 {
+            info!("Clear peer");
+            publish_event(ClearPeerEvent);
+        }
+        #[cfg(feature = "dongle")]
+        if id == NUM_BLE_PROFILE as u8 + 5 {
+            use crate::ble::profile::DONGLE_PROFILE;
+            info!("Dongle key held: clearing dongle bond, seeking a dongle");
+            BLE_PROFILE_CHANNEL
+                .send(BleProfileAction::ClearSlot(DONGLE_PROFILE))
+                .await;
+            BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(DONGLE_PROFILE)).await;
         }
     }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1030,7 +1030,6 @@ impl<'a> Keyboard<'a> {
             new_event.pressed = true;
             self.process_key_action(&action, new_event, true, Instant::now()).await;
             debug!("[Combo] {:?} triggered", action);
-            embassy_time::Timer::after_millis(20).await;
             // Reset other combos shadowed by the one that just fired.
             self.reset_shadowed_combos(&combo_actions);
         }

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -149,33 +149,23 @@ impl Runnable for Keyboard<'_> {
                 let e = self.unprocessed_events.remove(0);
                 debug!("Unprocessed event: {:?}", e);
                 self.process_inner(e).await
-            } else if let Some(key) = self.next_buffered_key() {
-                // Process buffered held key
-                self.process_buffered_key(key).await
             } else {
-                // If a mouse repeat or one-shot expiry is pending, race subscriber against the earliest deadline
-                let deadline = [self.mouse.next_deadline(), self.osm_deadline, self.osl_deadline]
-                    .into_iter()
-                    .flatten()
-                    .min();
-                let event = if let Some(deadline) = deadline {
-                    match with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure()).await {
-                        Ok(event) => event,
-                        Err(_) => {
-                            // Deadline expired: fire pending one-shot expiry and/or mouse repeat
-                            self.fire_oneshot_timeout().await;
-                            if self.mouse.next_deadline().is_some_and(|d| d <= Instant::now()) {
-                                self.fire_mouse_repeat().await;
-                            }
-                            continue;
-                        }
+                // Race the subscriber against the earliest pending deadline.
+                // `with_deadline` polls the subscriber first, so a queued event
+                // always wins over an already-expired deadline.
+                let event = match self.next_deadline() {
+                    Some(deadline) => {
+                        with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure())
+                            .await
+                            .ok()
                     }
-                } else {
-                    // No repeat pending, wait indefinitely
-                    self.keyboard_event_subscriber.next_message_pure().await
+                    None => Some(self.keyboard_event_subscriber.next_message_pure().await),
                 };
-                self.process_inner(event).await
-            };
+                match event {
+                    Some(event) => self.process_inner(event).await,
+                    None => self.fire_expired().await,
+                }
+            }
 
             // Run any macros triggered while handling the event.
             while let Ok((macro_idx, event)) = crate::channel::MACRO_TRIGGER_CHANNEL.try_receive() {
@@ -314,60 +304,57 @@ impl<'a> Keyboard<'a> {
         send_hid_report(report).await;
     }
 
-    /// Get a copy of the next timeout key in the buffer,
-    /// which is either a combo component that is waiting for other combo keys,
-    /// or a morse key that is in the pressed or released state.
-    pub fn next_buffered_key(&mut self) -> Option<HeldKey> {
+    /// Get a copy of the next timeout key in the buffer: a combo component
+    /// waiting out its combo window, or a morse key waiting out its timeout.
+    pub fn next_buffered_key(&self) -> Option<HeldKey> {
         self.held_buffer.next_timeout(|k| {
-            matches!(
-                k.state,
-                KeyState::Released(_) | KeyState::EarlyFired(_) | KeyState::WaitingCombo
-            ) || (matches!(k.state, KeyState::Pressed(_)) && k.action.is_morse())
+            matches!(k.state, KeyState::WaitingCombo)
+                || (k.action.is_morse()
+                    && matches!(
+                        k.state,
+                        KeyState::Pressed(_) | KeyState::Released(_) | KeyState::EarlyFired(_)
+                    ))
         })
     }
 
-    /// Process the latest buffered key.
-    ///
-    /// The given holding key is a copy of the buffered key. Only tap-hold keys are considered now.
-    pub async fn process_buffered_key(&mut self, key: HeldKey) {
-        debug!(
-            "Processing buffered key: \nevent: {:?} state: {:?}",
-            key.event, key.state
-        );
-        match key.state {
-            KeyState::WaitingCombo => {
-                debug!(
-                    "[Combo] Waiting combo, timeout in: {:?}ms",
-                    (key.timeout_time.saturating_duration_since(Instant::now())).as_millis()
-                );
-                match with_deadline(key.timeout_time, self.keyboard_event_subscriber.next_message_pure()).await {
-                    Ok(event) => {
-                        // Process new key event
-                        debug!("[Combo] Interrupted by a new key event: {:?}", event);
-                        self.process_inner(event).await;
-                    }
-                    Err(_timeout) => {
-                        // Timeout, dispatch combo
-                        debug!("[Combo] Timeout, dispatch combo");
-                        self.dispatch_combos(&key.action, key.event).await;
-                    }
+    /// `next_deadline()` and `fire_expired()` are a pair, kept adjacent and in
+    /// the same order: every source listed here must be cleared or advanced by
+    /// its `fire_*` once due, or `run()` spins on a deadline that never expires.
+    fn next_deadline(&self) -> Option<Instant> {
+        [
+            self.osm_deadline,
+            self.osl_deadline,
+            self.next_buffered_key().map(|k| k.timeout_time),
+            self.mouse.next_deadline(),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+    }
+
+    /// Fire every due deadline. Each `fire_*` re-checks its own deadline, so a
+    /// call before expiry is a no-op.
+    async fn fire_expired(&mut self) {
+        self.fire_oneshot_timeout().await;
+        self.fire_buffered_key_timeout().await;
+        self.fire_mouse_repeat().await;
+    }
+
+    /// Resolve one expired buffered key: dispatch the timed-out combo or the
+    /// morse timeout. One key per call: `run()` re-races the subscriber between
+    /// fires, so queued events preempt the next timeout.
+    async fn fire_buffered_key_timeout(&mut self) {
+        if let Some(key) = self.next_buffered_key().filter(|k| k.timeout_time <= Instant::now()) {
+            match key.state {
+                KeyState::WaitingCombo => {
+                    debug!("[Combo] Timeout, dispatch combo");
+                    self.dispatch_combos(&key.action, key.event).await;
+                }
+                _ => {
+                    debug!("Buffered morse key timeout");
+                    self.handle_morse_timeout(&key).await;
                 }
             }
-            KeyState::Pressed(_) | KeyState::Released(_) | KeyState::EarlyFired(_) if key.action.is_morse() => {
-                // Wait for timeout or new key event
-                info!("Waiting morse key: {:?}", key.action);
-                match with_deadline(key.timeout_time, self.keyboard_event_subscriber.next_message_pure()).await {
-                    Ok(event) => {
-                        debug!("Buffered morse key interrupted by a new key event: {:?}", event);
-                        self.process_inner(event).await;
-                    }
-                    Err(_timeout) => {
-                        debug!("Buffered morse key timeout");
-                        self.handle_morse_timeout(&key).await;
-                    }
-                }
-            }
-            _ => (),
         }
     }
 
@@ -2146,7 +2133,8 @@ mod test {
 
     async fn force_timeout_first_hold(keyboard: &mut Keyboard<'static>) {
         let key = keyboard.next_buffered_key().unwrap();
-        keyboard.process_buffered_key(key).await;
+        embassy_time::Timer::at(key.timeout_time).await;
+        keyboard.fire_buffered_key_timeout().await;
     }
 
     fn create_test_keyboard_with_forks(fork1: Fork, fork2: Fork) -> Keyboard<'static> {

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1211,17 +1211,23 @@ impl<'a> Keyboard<'a> {
     async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
         self.trigger_delayed_combo(key_action, event).await;
 
-        // Dispatch all keys with state `WaitingCombo` in the held buffer
-        let mut i = 0;
-        while i < self.held_buffer.keys.len() {
-            if self.held_buffer.keys[i].state == KeyState::WaitingCombo {
-                let key = self.held_buffer.keys.swap_remove(i);
-                debug!("[Combo] Dispatching combo: {:?}", key);
-                self.process_key_action(&key.action, key.event, false, key.press_time)
-                    .await;
-            } else {
-                i += 1;
-            }
+        // Dispatch every key waiting on a combo, earliest press first. Re-scan the
+        // buffer after each one instead of indexing it: dispatching a key can remove
+        // and re-push other entries (a held morse key resolving as a hold does), and
+        // an index taken before that shift skips the entry that moved into it.
+        while let Some(i) = self
+            .held_buffer
+            .keys
+            .iter()
+            .enumerate()
+            .filter(|(_, k)| k.state == KeyState::WaitingCombo)
+            .min_by_key(|(_, k)| k.press_time)
+            .map(|(i, _)| i)
+        {
+            let key = self.held_buffer.keys.remove(i);
+            debug!("[Combo] Dispatching combo: {:?}", key);
+            self.process_key_action(&key.action, key.event, false, key.press_time)
+                .await;
         }
 
         // Reset triggered combo states

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -140,9 +140,8 @@ impl Runnable for Keyboard<'_> {
     /// The report is sent using `send_report`.
     async fn run(&mut self) -> ! {
         loop {
-            // Race the subscriber against the earliest pending deadline.
-            // `with_deadline` polls the subscriber first, so a queued event
-            // always wins over an already-expired deadline.
+            // Wait for the next event, but wake up at the earliest pending deadline.
+            // `with_deadline` polls the subscriber first, so a queued event is handled first.
             let event = match self.next_deadline() {
                 Some(deadline) => with_deadline(deadline, self.keyboard_event_subscriber.next_message_pure())
                     .await
@@ -199,9 +198,8 @@ pub struct Keyboard<'a> {
     /// Expiry deadline while the oneshot modifiers are armed (`Single`)
     osm_deadline: Option<Instant>,
 
-    /// In-progress User-key hold gesture (5s bond-clear etc.): the expiry
-    /// deadline and the held key's user id. Any key event disarms it; only
-    /// true idle for the full window completes the gesture.
+    /// The pending User-key hold gesture: when it fires, and the id of the held key.
+    /// Any key event cancels it.
     #[cfg(feature = "_ble")]
     user_hold: Option<(Instant, u8)>,
 
@@ -295,8 +293,8 @@ impl<'a> Keyboard<'a> {
         send_hid_report(report).await;
     }
 
-    /// Get a copy of the next timeout key in the buffer: a combo component
-    /// waiting out its combo window, or a morse key waiting out its timeout.
+    /// A copy of the buffered key that times out first: a combo key waiting for
+    /// its partners, or a morse key waiting out its timeout.
     pub fn next_buffered_key(&self) -> Option<HeldKey> {
         self.held_buffer.next_timeout(|k| {
             matches!(k.state, KeyState::WaitingCombo)
@@ -308,12 +306,12 @@ impl<'a> Keyboard<'a> {
         })
     }
 
-    /// Every source here is cleared or advanced by its `fire_*` in
-    /// `fire_expired()` once due, or `run()` spins on it.
+    /// The earliest time `run()` must wake up. Every deadline returned here has to be
+    /// cleared or moved forward by `fire_expired`, otherwise `run()` busy-loops on it.
     fn next_deadline(&self) -> Option<Instant> {
         let buffered = self.next_buffered_key().map(|k| k.timeout_time);
-        // A buffered key still owns the one-shot it was pressed under, so the
-        // one-shot only expires while nothing is buffered.
+        // A buffered key may still use the one-shot it was pressed under, so the
+        // one-shot can only expire when the buffer is empty.
         let one_shot = if buffered.is_some() {
             None
         } else {
@@ -331,42 +329,42 @@ impl<'a> Keyboard<'a> {
         .min()
     }
 
-    /// Fire every due deadline. Each `fire_*` re-checks its own deadline, so a
-    /// call before expiry is a no-op.
+    /// Handle every deadline that is due. Each step checks its own deadline, so
+    /// calling this too early does nothing.
     async fn fire_expired(&mut self) {
-        // The buffered key fires in place of the one-shot it holds up (see `next_deadline`).
-        if self.next_buffered_key().is_some() {
-            self.fire_buffered_key_timeout().await;
-        } else {
-            self.fire_oneshot_timeout().await;
+        match self.next_buffered_key() {
+            // `next_deadline` hides the one-shot while a key is buffered, so at most
+            // one of these two can be due.
+            Some(key) => self.fire_buffered_key_timeout(key).await,
+            None => self.fire_oneshot_timeout().await,
         }
         #[cfg(feature = "_ble")]
         self.fire_user_hold().await;
         self.fire_mouse_repeat().await;
     }
 
-    /// Resolve one expired buffered key: dispatch the timed-out combo or the
-    /// morse timeout. One key per call: `run()` re-races the subscriber between
-    /// fires, so queued events preempt the next timeout.
-    async fn fire_buffered_key_timeout(&mut self) {
-        if let Some(key) = self.next_buffered_key().filter(|k| k.timeout_time <= Instant::now()) {
-            match key.state {
-                KeyState::WaitingCombo => {
-                    debug!("[Combo] Timeout, dispatch combo");
-                    self.dispatch_combos(&key.action, key.event).await;
-                }
-                _ => {
-                    debug!("Buffered morse key timeout");
-                    self.handle_morse_timeout(&key).await;
-                }
+    /// Resolve `key` if its timeout has passed: dispatch the combo it waits on, or
+    /// hand it to the morse timeout. Only one key per call, so `run()` can handle a
+    /// queued event before the next timeout.
+    async fn fire_buffered_key_timeout(&mut self, key: HeldKey) {
+        if key.timeout_time > Instant::now() {
+            return;
+        }
+        match key.state {
+            KeyState::WaitingCombo => {
+                debug!("[Combo] Timeout, dispatch combo");
+                self.dispatch_combos(&key.action, key.event).await;
+            }
+            _ => {
+                debug!("Buffered morse key timeout");
+                self.handle_morse_timeout(&key).await;
             }
         }
     }
 
     /// Process key changes at (row, col)
     pub async fn process_inner(&mut self, event: KeyboardEvent) {
-        // Any key event cancels a pending User-key hold gesture; only true
-        // idle for the full window completes it.
+        // A User-key hold gesture needs 5s without any key event, so cancel it here.
         #[cfg(feature = "_ble")]
         {
             self.user_hold = None;
@@ -434,8 +432,8 @@ impl<'a> Keyboard<'a> {
             KeyBehaviorDecision::Buffer => {
                 debug!("Current key is buffered");
                 if key_action.is_morse() {
-                    // The morse press path continues a pattern already at this position;
-                    // pushing here would leave two entries for one key.
+                    // A morse key may already have an entry here, and the morse press path
+                    // continues that pattern. Pushing would leave two entries for one key.
                     self.process_key_action_morse(key_action, event, event_time).await;
                 } else {
                     self.held_buffer.push(HeldKey::new(
@@ -1211,10 +1209,9 @@ impl<'a> Keyboard<'a> {
     async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
         self.trigger_delayed_combo(key_action, event).await;
 
-        // Dispatch every key waiting on a combo, earliest press first. Re-scan the
-        // buffer after each one instead of indexing it: dispatching a key can remove
-        // and re-push other entries (a held morse key resolving as a hold does), and
-        // an index taken before that shift skips the entry that moved into it.
+        // Dispatch every waiting key, earliest press first. Dispatching one key can
+        // remove and re-push others, so look the next one up again instead of
+        // reusing an index.
         while let Some(i) = self
             .held_buffer
             .keys
@@ -1686,10 +1683,6 @@ impl<'a> Keyboard<'a> {
         }
     }
 
-    /// How long a User key must stay held to trigger its hold gesture.
-    #[cfg(feature = "_ble")]
-    const USER_HOLD_DURATION: Duration = Duration::from_secs(5);
-
     async fn process_user(&mut self, id: u8, event: KeyboardEvent) {
         debug!("Processing user key id: {:?}, event: {:?}", id, event);
 
@@ -1699,18 +1692,11 @@ impl<'a> Keyboard<'a> {
             use crate::ble::profile::BleProfileAction;
             use crate::channel::BLE_PROFILE_CHANNEL;
             if event.pressed {
-                // The uniform gesture across all bond slots: tap switches, a 5s
-                // hold forgets the slot's bond, switches to it, then repairs.
-                let arm = id < NUM_BLE_PROFILE as u8;
-                #[cfg(feature = "split")]
-                let arm = arm || id == NUM_BLE_PROFILE as u8 + 4;
-                #[cfg(feature = "dongle")]
-                let arm = arm || id == NUM_BLE_PROFILE as u8 + 5;
-                if arm {
-                    self.user_hold = Some((Instant::now() + Self::USER_HOLD_DURATION, id));
-                }
+                // Start the 5s hold gesture for any user key. `fire_user_hold` decides
+                // which ids actually do something, so the id list lives in one place.
+                self.user_hold = Some((Instant::now() + Duration::from_secs(5), id));
             } else {
-                // A replayed press and release clear the hold.
+                // A tap sends press and release back to back, so cancel what the press started.
                 self.user_hold = None;
                 // Other user keys are processed when released.
                 if id < NUM_BLE_PROFILE as u8 {
@@ -1743,20 +1729,20 @@ impl<'a> Keyboard<'a> {
         }
     }
 
-    /// Fire an expired User-key hold gesture: clear the bond of the held slot
-    /// and switch to it (or clear the split peer). Reaching expiry implies no
-    /// key event intervened, since any event disarms the gesture.
+    /// Run the gesture of a User key held for the full 5s; ids without one do nothing.
+    /// Getting here means no key event arrived meanwhile, because any event cancels
+    /// the hold.
     #[cfg(feature = "_ble")]
     async fn fire_user_hold(&mut self) {
-        let Some((deadline, id)) = self.user_hold else { return };
-        if Instant::now() < deadline {
-            return;
-        }
-        self.user_hold = None;
-
         use crate::NUM_BLE_PROFILE;
         use crate::ble::profile::BleProfileAction;
         use crate::channel::BLE_PROFILE_CHANNEL;
+
+        let Some((_, id)) = self.user_hold.take_if(|(at, _)| *at <= Instant::now()) else {
+            return;
+        };
+
+        // Tapping a bond slot switches to it; holding it forgets the bond, switches, then re-pairs.
         if id < NUM_BLE_PROFILE as u8 {
             info!("Profile key held: clearing bond on profile {}", id);
             BLE_PROFILE_CHANNEL.send(BleProfileAction::ClearSlot(id)).await;
@@ -2155,7 +2141,7 @@ mod test {
     async fn force_timeout_first_hold(keyboard: &mut Keyboard<'static>) {
         let key = keyboard.next_buffered_key().unwrap();
         embassy_time::Timer::at(key.timeout_time).await;
-        keyboard.fire_buffered_key_timeout().await;
+        keyboard.fire_buffered_key_timeout(key).await;
     }
 
     fn create_test_keyboard_with_forks(fork1: Fork, fork2: Fork) -> Keyboard<'static> {

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -515,7 +515,7 @@ impl<'a> Keyboard<'a> {
                                 self.process_key_action_normal(action, held_key.event).await;
                                 held_key.state = KeyState::ProcessedButReleaseNotReportedYet(action);
                                 // Push back after triggered tap
-                                self.held_buffer.push_without_sort(held_key);
+                                self.held_buffer.push(held_key);
                             }
                             KeyState::Released(pattern) => {
                                 // In this state pattern is not surely finished,
@@ -554,7 +554,7 @@ impl<'a> Keyboard<'a> {
                                     self.process_key_action_normal(action, held_key.event).await;
                                     held_key.state = KeyState::ProcessedButReleaseNotReportedYet(action);
                                     // Push back after triggered hold
-                                    self.held_buffer.push_without_sort(held_key);
+                                    self.held_buffer.push(held_key);
                                 }
                                 KeyState::Released(pattern) => {
                                     debug!("pattern after released, permissive hold: {:?}", pattern);
@@ -627,7 +627,7 @@ impl<'a> Keyboard<'a> {
                                 _ => {} // For morse, the releasing will not be processed immediately, so just ignore it
                             }
                             // Push back after triggered hold
-                            self.held_buffer.push_without_sort(held_key);
+                            self.held_buffer.push(held_key);
                         }
                     }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1700,11 +1700,7 @@ impl<'a> Keyboard<'a> {
             use crate::channel::BLE_PROFILE_CHANNEL;
             if event.pressed {
                 // The uniform gesture across all bond slots: tap switches, a 5s
-                // hold forgets the slot's bond and re-pairs (holding a profile key
-                // clears that profile and switches to it, so it advertises openly;
-                // the dongle key seeks a new dongle; the peer key clears the split
-                // peer). The hold is deadline-driven from `run()`: arming returns
-                // immediately, so the task keeps servicing events while it's down.
+                // hold forgets the slot's bond, switches to it, then repairs.
                 let arm = id < NUM_BLE_PROFILE as u8;
                 #[cfg(feature = "split")]
                 let arm = arm || id == NUM_BLE_PROFILE as u8 + 4;
@@ -1714,11 +1710,9 @@ impl<'a> Keyboard<'a> {
                     self.user_hold = Some((Instant::now() + Self::USER_HOLD_DURATION, id));
                 }
             } else {
-                // A replayed press and release must not leave the gesture armed.
+                // A replayed press and release clear the hold.
                 self.user_hold = None;
                 // Other user keys are processed when released.
-                // Slots 0..NUM_BLE_PROFILE select a profile directly; the next four are
-                // fixed actions stacked on top.
                 if id < NUM_BLE_PROFILE as u8 {
                     info!("Switch to profile: {}", id);
                     BLE_PROFILE_CHANNEL.send(BleProfileAction::Switch(id)).await;
@@ -1737,9 +1731,7 @@ impl<'a> Keyboard<'a> {
                     #[cfg(not(feature = "_no_usb"))]
                     crate::state::toggle_preferred().await;
                 }
-                // Short press of the dongle key: switch to the dongle slot. Also runs
-                // after a 5s hold, where it is a no-op (the hold already put the
-                // keyboard on the dongle profile or was an in-place authorization).
+                // Switch to the dongle slot.
                 #[cfg(feature = "dongle")]
                 if id == NUM_BLE_PROFILE as u8 + 5 {
                     info!("Switch to dongle profile");

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -308,16 +308,22 @@ impl<'a> Keyboard<'a> {
         })
     }
 
-    /// `next_deadline()` and `fire_expired()` are a pair, kept adjacent and in
-    /// the same order: every source listed here must be cleared or advanced by
-    /// its `fire_*` once due, or `run()` spins on a deadline that never expires.
+    /// Every source here is cleared or advanced by its `fire_*` in
+    /// `fire_expired()` once due, or `run()` spins on it.
     fn next_deadline(&self) -> Option<Instant> {
+        let buffered = self.next_buffered_key().map(|k| k.timeout_time);
+        // A buffered key still owns the one-shot it was pressed under, so the
+        // one-shot only expires while nothing is buffered.
+        let one_shot = if buffered.is_some() {
+            None
+        } else {
+            [self.osm_deadline, self.osl_deadline].into_iter().flatten().min()
+        };
         [
-            self.osm_deadline,
-            self.osl_deadline,
+            one_shot,
             #[cfg(feature = "_ble")]
             self.user_hold.map(|(at, _)| at),
-            self.next_buffered_key().map(|k| k.timeout_time),
+            buffered,
             self.mouse.next_deadline(),
         ]
         .into_iter()
@@ -328,10 +334,14 @@ impl<'a> Keyboard<'a> {
     /// Fire every due deadline. Each `fire_*` re-checks its own deadline, so a
     /// call before expiry is a no-op.
     async fn fire_expired(&mut self) {
-        self.fire_oneshot_timeout().await;
+        // The buffered key fires in place of the one-shot it holds up (see `next_deadline`).
+        if self.next_buffered_key().is_some() {
+            self.fire_buffered_key_timeout().await;
+        } else {
+            self.fire_oneshot_timeout().await;
+        }
         #[cfg(feature = "_ble")]
         self.fire_user_hold().await;
-        self.fire_buffered_key_timeout().await;
         self.fire_mouse_repeat().await;
     }
 

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -1708,6 +1708,8 @@ impl<'a> Keyboard<'a> {
                     self.user_hold = Some((Instant::now() + Self::USER_HOLD_DURATION, id));
                 }
             } else {
+                // A replayed press and release must not leave the gesture armed.
+                self.user_hold = None;
                 // Other user keys are processed when released.
                 // Slots 0..NUM_BLE_PROFILE select a profile directly; the next four are
                 // fixed actions stacked on top.

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -423,18 +423,19 @@ impl<'a> Keyboard<'a> {
             }
             KeyBehaviorDecision::Buffer => {
                 debug!("Current key is buffered");
-                let timeout_time = if key_action.is_morse() {
-                    event_time + Self::morse_timeout(self.keymap, key_action, true)
+                if key_action.is_morse() {
+                    // The morse press path continues a pattern already at this position;
+                    // pushing here would leave two entries for one key.
+                    self.process_key_action_morse(key_action, event, event_time).await;
                 } else {
-                    event_time
-                };
-                self.held_buffer.push(HeldKey::new(
-                    event,
-                    *key_action,
-                    KeyState::Pressed(MorsePattern::default()),
-                    event_time,
-                    timeout_time,
-                ));
+                    self.held_buffer.push(HeldKey::new(
+                        event,
+                        *key_action,
+                        KeyState::Pressed(MorsePattern::default()),
+                        event_time,
+                        event_time,
+                    ));
+                }
             }
             KeyBehaviorDecision::Ignore => {
                 debug!("Current key is ignored or not buffered, process normally: {:?}", event);

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -2329,9 +2329,7 @@ mod test {
 
             // Here release event should make again into hold
 
-            // Under embassy-time/mock-driver (the test config), `Timer::after`
-            // would never resolve here because nothing else drives the clock.
-            // Bump virtual time directly.
+            // Skip ahead 200ms of virtual time.
             embassy_time::MockDriver::get().advance(Duration::from_millis(200));
             // after another key is pressed, that key is repeated
             keyboard.process_inner(KeyboardEvent::key(0, 0, true)).await;
@@ -2600,9 +2598,7 @@ mod test {
             assert_eq!(keyboard.resolve_modifiers(false), ModifierCombination::new());
             assert_eq!(keyboard.mouse.report.buttons, 0);
 
-            // Under embassy-time/mock-driver (the test config), `Timer::after`
-            // would never resolve here because nothing else drives the clock.
-            // Bump virtual time directly.
+            // Skip ahead 200ms of virtual time.
             embassy_time::MockDriver::get().advance(Duration::from_millis(200));
 
             // Press Z key, by itself it should emit 'MouseBtn5'

--- a/rmk/src/keyboard/held_buffer.rs
+++ b/rmk/src/keyboard/held_buffer.rs
@@ -4,7 +4,8 @@ use rmk_types::morse::MorsePattern;
 
 use crate::event::{KeyboardEvent, KeyboardEventPos};
 
-/// The buffer of held keys.
+/// The buffer of held keys, kept in insertion order: `next_timeout` scans for the
+/// earliest deadline, and callers that need press order sort by `press_time` themselves.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HeldBuffer {
@@ -20,18 +21,8 @@ impl HeldBuffer {
         }
     }
 
-    /// Push a new held key into the buffer and then sort by the timeout
-    pub fn push(&mut self, key: HeldKey) {
-        if let Err(e) = self.keys.push(key) {
-            error!("Held buffer overflowed, cannot save: {:?}", e);
-        }
-
-        // Sort the buffer after push
-        self.keys.sort_unstable_by_key(|k| k.timeout_time);
-    }
-
     /// Push a new held key into the buffer
-    pub fn push_without_sort(&mut self, key: HeldKey) {
+    pub fn push(&mut self, key: HeldKey) {
         if let Err(e) = self.keys.push(key) {
             error!("Held buffer overflowed, cannot save: {:?}", e);
         }
@@ -64,21 +55,21 @@ impl HeldBuffer {
         }
     }
 
-    /// Remove a held key from the buffer and then resort the buffer
+    /// Remove the held key at `pos`
     pub fn remove(&mut self, pos: KeyboardEventPos) -> Option<HeldKey> {
-        let k = self.remove_if(|k| k.event.pos == pos);
-        // Re-sort the buffer after remove
-        self.keys.sort_unstable_by_key(|k| k.timeout_time);
-        k
+        self.remove_if(|k| k.event.pos == pos)
     }
 
-    /// Get the next timeout key in the buffer
+    /// Get the key with the earliest timeout among those matching `predicate`.
     pub fn next_timeout<P>(&self, mut predicate: P) -> Option<HeldKey>
     where
         P: FnMut(&HeldKey) -> bool,
     {
-        // Support that the held buffer is already sorted by the timeout time
-        self.keys.iter().find(|&x| predicate(x)).copied()
+        self.keys
+            .iter()
+            .filter(|k| predicate(k))
+            .min_by_key(|k| k.timeout_time)
+            .copied()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/rmk/src/keyboard/held_buffer.rs
+++ b/rmk/src/keyboard/held_buffer.rs
@@ -55,11 +55,6 @@ impl HeldBuffer {
         }
     }
 
-    /// Remove the held key at `pos`
-    pub fn remove(&mut self, pos: KeyboardEventPos) -> Option<HeldKey> {
-        self.remove_if(|k| k.event.pos == pos)
-    }
-
     /// Get the key with the earliest timeout among those matching `predicate`.
     pub fn next_timeout<P>(&self, mut predicate: P) -> Option<HeldKey>
     where

--- a/rmk/src/keyboard/held_buffer.rs
+++ b/rmk/src/keyboard/held_buffer.rs
@@ -4,8 +4,7 @@ use rmk_types::morse::MorsePattern;
 
 use crate::event::{KeyboardEvent, KeyboardEventPos};
 
-/// The buffer of held keys, kept in insertion order: `next_timeout` scans for the
-/// earliest deadline, and callers that need press order sort by `press_time` themselves.
+/// The buffer of held keys.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct HeldBuffer {

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -168,7 +168,6 @@ impl<'a> Keyboard<'a> {
                                 k.press_time = released_time;
                                 k.timeout_time = released_time + keep_alive;
                             }
-                            self.held_buffer.keys.sort_unstable_by_key(|k| k.timeout_time);
                             if !self.has_unresolved_morse_key() {
                                 self.fire_held_non_morse_keys().await;
                             }
@@ -270,8 +269,6 @@ impl<'a> Keyboard<'a> {
                 _ => (),
             }
         }
-
-        self.held_buffer.keys.sort_unstable_by_key(|k| k.timeout_time);
     }
 
     fn has_unresolved_morse_key(&self) -> bool {

--- a/rmk/src/keyboard/morse.rs
+++ b/rmk/src/keyboard/morse.rs
@@ -38,11 +38,11 @@ impl<'a> Keyboard<'a> {
                 // The time since the key release is longer than the timeout, trigger the action
                 let action = Self::action_from_pattern(self.keymap, &key.action, pattern);
                 self.process_key_action_tap(action, key.event).await;
-                let _ = self.held_buffer.remove(key.event.pos);
+                let _ = self.held_buffer.remove_if(|k| k.event.pos == key.event.pos);
             }
             KeyState::EarlyFired(_) => {
                 // Tap was already fired early, just clean up
-                let _ = self.held_buffer.remove(key.event.pos);
+                let _ = self.held_buffer.remove_if(|k| k.event.pos == key.event.pos);
             }
             _ => unreachable!(),
         };
@@ -174,7 +174,7 @@ impl<'a> Keyboard<'a> {
                         } else if let Some(action) = final_action {
                             debug!("released prediction {:?} -> {:?}", pattern, action);
                             // Reached the longest configured morse pattern, trigger the corresponding action immediately
-                            self.held_buffer.remove(event.pos); // Remove the key from the held buffer, is like setting to an idle state
+                            self.held_buffer.remove_if(|k| k.event.pos == event.pos); // Remove the key from the held buffer, is like setting to an idle state
 
                             debug!(
                                 "Reached the longest configured morse pattern, trigger corresponding action {:?} immediately",
@@ -185,7 +185,7 @@ impl<'a> Keyboard<'a> {
                             let mut press_event = event;
                             press_event.pressed = true;
                             self.process_key_action_tap(action, press_event).await;
-                            self.held_buffer.remove(event.pos); // Remove the key from the held buffer, is like setting to an idle state
+                            self.held_buffer.remove_if(|k| k.event.pos == event.pos); // Remove the key from the held buffer, is like setting to an idle state
                         } else {
                             // Expect a possible longer morse pattern (or idle timeout), update the state
                             let early_action = Self::check_early_fire(self.keymap, &k.action, pattern);
@@ -225,7 +225,7 @@ impl<'a> Keyboard<'a> {
                     KeyState::ProcessedButReleaseNotReportedYet(action) => {
                         // Releasing a tap-hold action whose pressed HID report is already sent
                         info!("Releasing a morse action whose pressed action is already triggered");
-                        let _ = self.held_buffer.remove(event.pos);
+                        let _ = self.held_buffer.remove_if(|k| k.event.pos == event.pos);
                         // Process the release action
                         debug!("[morse] Releasing morse key: {:?}", event);
                         self.process_key_action_normal(action, event).await;
@@ -247,7 +247,7 @@ impl<'a> Keyboard<'a> {
                                 k.timeout_time = now + timeout;
                             }
                         } else {
-                            let _ = self.held_buffer.remove(event.pos);
+                            let _ = self.held_buffer.remove_if(|k| k.event.pos == event.pos);
                         }
                     }
                     _ => {}

--- a/rmk/tests/integration/ble_profile.rs
+++ b/rmk/tests/integration/ble_profile.rs
@@ -39,3 +39,15 @@ fn intervening_key_cancels_the_hold() {
         assert_eq!(keyboard.ble_profile_actions(), ["Switch(0)"]);
     });
 }
+
+// Regression: the tap side of a tap-hold armed the hold on its synthesized
+// press, nothing disarmed it, and the bond was wiped after 5s of idle.
+#[test]
+fn tapped_profile_key_action_does_not_clear_its_bond() {
+    test_block_on(async {
+        let tap_hold = KeyAction::TapHold(Action::User(0), Action::Key(KeyCode::Hid(HidKeyCode::Z)), u8::MAX);
+        let mut keyboard = SimKeyboard::builder([[[tap_hold]]]).build().await;
+        keyboard.tap(0, 0, 20).delay(5200).run().await;
+        assert_eq!(keyboard.ble_profile_actions(), ["Switch(0)"]);
+    });
+}

--- a/rmk/tests/integration/ble_profile.rs
+++ b/rmk/tests/integration/ble_profile.rs
@@ -1,0 +1,41 @@
+//! Profile-key gestures, which a scenario cannot observe: the harness records
+//! what the keyboard sent the BLE profile task.
+
+use rmk::k;
+use rmk::test_support::test_block_on;
+use rmk::types::action::{Action, KeyAction};
+use rmk::types::keycode::{HidKeyCode, KeyCode};
+
+use crate::simulator::SimKeyboard;
+
+const USER0: KeyAction = KeyAction::Single(Action::User(0));
+
+#[test]
+fn held_profile_key_clears_its_bond_after_5s() {
+    test_block_on(async {
+        let mut keyboard = SimKeyboard::builder([[[USER0]]]).build().await;
+        keyboard.press(0, 0).delay(5100).release(0, 0).run().await;
+        assert_eq!(
+            keyboard.ble_profile_actions(),
+            ["ClearSlot(0)", "Switch(0)", "Switch(0)"]
+        );
+    });
+}
+
+#[test]
+fn intervening_key_cancels_the_hold() {
+    test_block_on(async {
+        let mut keyboard = SimKeyboard::builder([[[USER0, k!(A)]]]).build().await;
+        keyboard
+            .press(0, 0)
+            .delay(100)
+            .tap(0, 1, 10)
+            .expect_keys([HidKeyCode::A])
+            .expect_keys([])
+            .release(0, 0)
+            .delay(5200)
+            .run()
+            .await;
+        assert_eq!(keyboard.ble_profile_actions(), ["Switch(0)"]);
+    });
+}

--- a/rmk/tests/integration/ble_profile.rs
+++ b/rmk/tests/integration/ble_profile.rs
@@ -40,6 +40,26 @@ fn intervening_key_cancels_the_hold() {
     });
 }
 
+// Typing over a held profile key cancels the gesture: the key stays down past
+// the 5s mark, so only the intervening press can disarm it.
+#[test]
+fn key_pressed_while_the_profile_key_is_down_cancels_the_bond_clear() {
+    test_block_on(async {
+        let mut keyboard = SimKeyboard::builder([[[USER0, k!(A)]]]).build().await;
+        keyboard
+            .press(0, 0)
+            .delay(100)
+            .tap(0, 1, 10)
+            .expect_keys([HidKeyCode::A])
+            .expect_keys([])
+            .delay(5200)
+            .release(0, 0)
+            .run()
+            .await;
+        assert_eq!(keyboard.ble_profile_actions(), ["Switch(0)"]);
+    });
+}
+
 // Regression: the tap side of a tap-hold armed the hold on its synthesized
 // press, nothing disarmed it, and the bond was wiped after 5s of idle.
 #[test]

--- a/rmk/tests/integration/main.rs
+++ b/rmk/tests/integration/main.rs
@@ -2,9 +2,9 @@
 //!
 //! [`simulator`] is the harness every case runs on. `run_tests!` expands each
 //! `scenarios/*.toml` into a `mod` of keyboard-behavior tests;
-//! `scenarios/README.md` documents their syntax. [`rynk`] and [`vial`] hold what
-//! a scenario file cannot express: wire-protocol writes interleaved with matrix
-//! input.
+//! `scenarios/README.md` documents their syntax. [`rynk`], [`vial`], and
+//! [`ble_profile`] hold what a scenario file cannot express: wire-protocol
+//! writes interleaved with matrix input, and what the BLE profile task received.
 
 // The harness offers the whole step vocabulary, and each feature row plays a
 // subset of it — so per-row dead code is expected, not a finding.
@@ -12,6 +12,8 @@
 
 mod simulator;
 
+#[cfg(feature = "_ble")]
+mod ble_profile;
 #[cfg(feature = "rynk")]
 mod rynk;
 #[cfg(feature = "vial")]

--- a/rmk/tests/integration/simulator/mod.rs
+++ b/rmk/tests/integration/simulator/mod.rs
@@ -396,11 +396,6 @@ impl SimKeyboard {
             "leak after buffer cleanup, buffer contains {:?}",
             self.keyboard.held_buffer
         );
-        assert!(
-            self.keyboard.unprocessed_events.is_empty(),
-            "simulator ended with unprocessed keyboard events: {:?}",
-            self.keyboard.unprocessed_events
-        );
     }
 }
 

--- a/rmk/tests/integration/simulator/mod.rs
+++ b/rmk/tests/integration/simulator/mod.rs
@@ -13,6 +13,7 @@ pub mod flash;
 
 use core::future::Future;
 use core::pin::Pin;
+use std::cell::RefCell;
 
 #[cfg(feature = "storage")]
 use embassy_embedded_hal::adapter::BlockingAsync;
@@ -134,6 +135,7 @@ impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_ENCOD
             rmk_config: self.rmk_config,
             steps: Vec::new(),
             storage: None,
+            ble_profile_actions: Vec::new(),
         }
     }
 
@@ -159,6 +161,7 @@ impl<const ROW: usize, const COL: usize, const NUM_LAYER: usize, const NUM_ENCOD
             rmk_config: self.rmk_config,
             steps: Vec::new(),
             storage: Some(Box::pin(async move { storage.run().await })),
+            ble_profile_actions: Vec::new(),
         }
     }
 }
@@ -196,6 +199,7 @@ pub struct SimKeyboard {
     rmk_config: RmkConfig<'static>,
     steps: Vec<SimStep>,
     storage: Option<Pin<Box<dyn Future<Output = ()>>>>,
+    ble_profile_actions: Vec<String>,
 }
 
 impl SimKeyboard {
@@ -364,6 +368,13 @@ impl SimKeyboard {
                 None => rmk::channel::drain_flash_channel_for_test().await,
             }
         };
+        // Likewise for the BLE profile task; what it received is kept for assertions.
+        let profile_actions = RefCell::new(Vec::new());
+        #[cfg(feature = "_ble")]
+        let profiles =
+            rmk::channel::drain_ble_profile_channel_for_test(|action| profile_actions.borrow_mut().push(action));
+        #[cfg(not(feature = "_ble"))]
+        let profiles = core::future::pending::<()>();
 
         // A host connection is just a byte stream: drive the production
         // `run_session` over an in-memory duplex, exactly as a USB/BLE transport
@@ -385,17 +396,23 @@ impl SimKeyboard {
         // None of these ever return; the timeline does, and dropping them is how
         // a run ends. One resolving first means a task died or, for the session,
         // that a framing guard rejected the stream.
-        let background = select(keyboard.run(), select(flash, session));
+        let background = select(keyboard.run(), select(select(flash, profiles), session));
         match select(background, run_steps(steps, &to_device, &from_device)).await {
             Either::First(_) => panic!("a background task ended before the scripted steps finished"),
             Either::Second(()) => {}
         }
+        self.ble_profile_actions = profile_actions.into_inner();
 
         assert!(
             self.keyboard.held_buffer.is_empty(),
             "leak after buffer cleanup, buffer contains {:?}",
             self.keyboard.held_buffer
         );
+    }
+
+    /// What the keyboard sent the BLE profile task during `run`, in `Debug` form.
+    pub fn ble_profile_actions(&self) -> &[String] {
+        &self.ble_profile_actions
     }
 }
 

--- a/rmk/tests/integration/simulator/mod.rs
+++ b/rmk/tests/integration/simulator/mod.rs
@@ -13,11 +13,10 @@ pub mod flash;
 
 use core::future::Future;
 use core::pin::Pin;
-use std::cell::RefCell;
 
 #[cfg(feature = "storage")]
 use embassy_embedded_hal::adapter::BlockingAsync;
-use embassy_futures::select::{Either, select};
+use embassy_futures::select::{Either, select, select4};
 use embassy_futures::yield_now;
 use embassy_time::{Duration, Timer};
 #[cfg(feature = "storage")]
@@ -368,13 +367,9 @@ impl SimKeyboard {
                 None => rmk::channel::drain_flash_channel_for_test().await,
             }
         };
-        // Likewise for the BLE profile task; what it received is kept for assertions.
-        let profile_actions = RefCell::new(Vec::new());
-        #[cfg(feature = "_ble")]
-        let profiles =
-            rmk::channel::drain_ble_profile_channel_for_test(|action| profile_actions.borrow_mut().push(action));
-        #[cfg(not(feature = "_ble"))]
-        let profiles = core::future::pending::<()>();
+        // Same for the BLE profile task, but keep what it received so tests can check it.
+        let mut profile_actions = Vec::new();
+        let profiles = rmk::channel::drain_ble_profile_channel_for_test(&mut profile_actions);
 
         // A host connection is just a byte stream: drive the production
         // `run_session` over an in-memory duplex, exactly as a USB/BLE transport
@@ -396,12 +391,12 @@ impl SimKeyboard {
         // None of these ever return; the timeline does, and dropping them is how
         // a run ends. One resolving first means a task died or, for the session,
         // that a framing guard rejected the stream.
-        let background = select(keyboard.run(), select(select(flash, profiles), session));
+        let background = select4(keyboard.run(), flash, profiles, session);
         match select(background, run_steps(steps, &to_device, &from_device)).await {
             Either::First(_) => panic!("a background task ended before the scripted steps finished"),
             Either::Second(()) => {}
         }
-        self.ble_profile_actions = profile_actions.into_inner();
+        self.ble_profile_actions = profile_actions;
 
         assert!(
             self.keyboard.held_buffer.is_empty(),

--- a/rmk/tests/scenarios/README.md
+++ b/rmk/tests/scenarios/README.md
@@ -64,7 +64,8 @@ splits by resolution mode. Those all start with `morse_`, so
 | `morse_combo_*` | One combo table over morse keys, under each of those modes |
 | `morse_tap_dance`, `morse_bilateral`, `morse_rollover`, `morse_layer_release`, `morse_quick_tap` | Morse behavior that isn't mode-specific |
 | `rynk_*` | The Rynk host protocol, one file per endpoint group |
-| everything else | One feature each — `combo`, `one_shot`, `layer`, `encoder`, `macros`, `hid_reports`, `passkey`, `steno` |
+| `deadline_race` | Deadlines that must keep firing while a key is buffered |
+| everything else | One feature each — `combo`, `one_shot`, `layer`, `encoder`, `macros`, `hid_reports`, `passkey`, `steno`, `user_hold` |
 
 Cases that only differ by mode share a name across files, so
 `nextest run two_key_misses_window` runs that case under every mode at once —

--- a/rmk/tests/scenarios/boards/split.toml
+++ b/rmk/tests/scenarios/boards/split.toml
@@ -37,7 +37,7 @@ pin_b = "P0_03"
 
 [[keymap.layer]]
 keys = """
-OSM(LShift)    OSL(1)         A            TH(B, C)  OSM(LCtrl)  WM(B, LGui)   MACRO(0)           MACRO(1)           MouseWheelUp  MouseAccel2  PDF(1)     A      LM(1, LShift)  No
+OSM(LShift)    OSL(1)         A            TH(B, C)  OSM(LCtrl)  WM(B, LGui)   MACRO(0)           MACRO(1)           MouseWheelUp  MouseAccel2  PDF(1)     A      LM(1, LShift)  User0
 A              MT(B, LShift)  TD(0)        W         E           R             T                  MT(C, LGui)        LT(1, D)      MT(E, LAlt)  Y          U      I              O
 TH(A, LShift)  TH(S, LGui)    TH(Z, LAlt)  V         B           N             D                  M                  Comma         Dot          L          X      C              F
 MO(1)          No             A            A         Space       LT(1, D, p0)  MT(B, LShift, p0)  MT(B, LShift, p1)  TD(1)         Enter        Backspace  TD(2)  No             No

--- a/rmk/tests/scenarios/combo.toml
+++ b/rmk/tests/scenarios/combo.toml
@@ -353,3 +353,28 @@ behavior.combo = {
 }
 steps = [{ tap = { pos = [0, 8], duration = 120 } }, { delay = 300 }]
 expect = [{ mouse = { wheel = -1 } }, { mouse = {} }]
+
+# Three overlapping pairs delayed behind a four-key combo: releasing E fires
+# ER, and releasing R right after must not fire the WR pair that ER shadows.
+# The shadowed pairs are reset synchronously when ER triggers; a deferred
+# reset would leave WR armed for the second release.
+[[test]]
+name = "shadowed_pair_does_not_fire_on_second_release"
+behavior.combo = {
+  timeout = "100ms",
+  combos = [
+    { actions = ["W", "E"], output = "A", layer = 0 },
+    { actions = ["E", "R"], output = "B", layer = 0 },
+    { actions = ["W", "R"], output = "C", layer = 0 },
+    { actions = ["W", "E", "R", "T"], output = "D", layer = 0 },
+  ]
+}
+steps = [
+  { press = [1, 3] },    # W
+  { press = [1, 5] },    # R: W+R back to back, so WR is fully pressed too
+  { press = [1, 4] },    # E
+  { release = [1, 4] },  # ER fires (B)
+  { release = [1, 5] },  # 10ms later: WR must stay quiet
+  { release = [1, 3] },  # the leftover W dispatches on its release
+]
+expect = [["B"], [], ["W"], []]

--- a/rmk/tests/scenarios/combo.toml
+++ b/rmk/tests/scenarios/combo.toml
@@ -3,8 +3,8 @@
 # Combos match on actions, so they fire wherever those keys live on the shared
 # split board: W@(1,3) E@(1,4) R@(1,5) T@(1,6); V@(2,3) B@(2,4) N@(2,5)
 # M@(2,7) Comma@(2,8) Dot@(2,9); the tap-hold trio TH(A, LShift)@(2,0)
-# TH(S, LGui)@(2,1) TH(Z, LAlt)@(2,2); and the mouse keys MouseWheelUp@(0,8)
-# MouseAccel2@(0,9).
+# TH(S, LGui)@(2,1) TH(Z, LAlt)@(2,2); the home-row MT(B, LShift)@(1,1); and the
+# mouse keys MouseWheelUp@(0,8) MouseAccel2@(0,9).
 #
 # Standard combos below are shared by most tests; tests with their own combo
 # set replace the array via `behavior.combo`.
@@ -202,6 +202,31 @@ steps = [
   { release = [2, 2] }, # Release Z
 ]
 expect = [["C"], []]
+
+# Three keys waiting on a four-key combo behind an unresolved MT(B, LShift), then
+# an unrelated press: W's dispatch resolves the MT as a hold, which removes and
+# re-pushes its entry. Regression: the dispatch loop indexed the buffer, so that
+# shift skipped E and R reached the host before it (W R E instead of W E R).
+[[test]]
+name = "waiting_combo_keys_keep_press_order_when_morse_hold_resolves"
+behavior.morse = { hold_on_other_press = true, hold_timeout = "250ms" }
+behavior.combo = {
+  timeout = "100ms",
+  combos = [{ actions = ["W", "E", "R", "T"], output = "D", layer = 0 }]
+}
+steps = [
+  { press = [1, 1] },    # MT(B, LShift), unresolved
+  { press = [1, 3] },    # W
+  { press = [1, 4] },    # E
+  { press = [1, 5] },    # R: all three wait on WERT
+  { press = [2, 3] },    # V interrupts: MT resolves as hold, then W E R V in press order
+  { release = [2, 3] },
+  { release = [1, 5] },
+  { release = [1, 4] },
+  { release = [1, 3] },
+  { release = [1, 1] },
+]
+expect = [["LShift"], ["LShift", "W"], ["LShift", "W", "E"], ["LShift", "W", "E", "R"], ["LShift", "W", "E", "R", "V"], ["LShift", "W", "E", "R"], ["LShift", "W", "E"], ["LShift", "W"], ["LShift"], []]
 
 # Reproduces a single-combo stuck-key bug: re-pressing a combo key while the
 # combo is still held leaked the re-press into the HID report and overwrote the

--- a/rmk/tests/scenarios/deadline_race.toml
+++ b/rmk/tests/scenarios/deadline_race.toml
@@ -1,0 +1,28 @@
+# The keyboard task races every pending deadline at one wait point, so a
+# behavior that is waiting out its own timeout must not stall the others.
+#
+# Board positions used: MouseWheelUp@(0,8), TH(B, C)@(0,3).
+
+keyboard = "boards/split.toml"
+
+# Regression: the buffered-key wait used to race only its own timeout, so a
+# held morse key froze mouse repeats until the next key event arrived.
+[[test]]
+name = "buffered_morse_wait_does_not_stall_mouse_repeats"
+behavior.morse = { hold_timeout = "400ms" }
+steps = [
+  { press = [0, 8] },   # Wheel: initial delta, repeats due at +100/+180ms
+  { delay = 20 },
+  { press = [0, 3] },   # TH(B, C): buffered, waiting out the 400ms hold timeout
+  { delay = 210 },      # covers two repeat ticks while the morse key waits
+  { release = [0, 3] }, # well before the hold timeout: resolves as tap B
+  { delay = 20 },
+  { release = [0, 8] },
+]
+expect = [
+  { mouse = { wheel = -1 } },
+  { mouse = { wheel = -1 } },  # repeat while the morse key is buffered
+  { mouse = { wheel = -1 } },  # repeat
+  ["B"], [],
+  { mouse = {} },
+]

--- a/rmk/tests/scenarios/morse_normal.toml
+++ b/rmk/tests/scenarios/morse_normal.toml
@@ -244,3 +244,21 @@ steps = [
   { tap = { pos = [1, 2], duration = 300 } },
 ]
 expect = [["R"], [], ["M"], [], ["K"], []]
+
+# Two morse keys with different hold timeouts held together: a plain key
+# pressed after them re-sorts the held buffer by press time, and the shorter
+# timeout must still fire on time, not when the longer one does.
+[[test]]
+name = "shorter_hold_timeout_fires_before_longer_one"
+behavior.morse = { unilateral_tap = false, profiles = { p0 = { hold_timeout = "100ms" } } }
+steps = [
+  { press = [1, 8] },                          # LT(1, D): hold due at +250
+  { press = [3, 6] },                          # MT(B, LShift, p0): hold due at +100
+  { tap = { pos = [1, 0], duration = 10 } },   # A: re-sorts the held buffer by press time
+  { delay = 150 },                             # MT hold is 70ms overdue, LT still pending
+  { tap = { pos = [1, 11], duration = 10 } },  # U: must be shifted
+  { delay = 100 },                             # LT hold fires (layer 1, no report)
+  { release = [3, 6] },
+  { release = [1, 8] },
+]
+expect = [["A"], [], ["LShift"], ["LShift", "U"], ["LShift"], []]

--- a/rmk/tests/scenarios/morse_permissive_hold.toml
+++ b/rmk/tests/scenarios/morse_permissive_hold.toml
@@ -299,3 +299,38 @@ steps = [
   { release = [1, 8] },
 ]
 expect = [["A"], [], ["Kp2"], []]
+
+# A tap-dance key re-pressed within its gap while a permissive-hold key is
+# unresolved: the press must continue the pattern in place, not add a second
+# entry at the same position that splits it into a lone tap plus a fresh hold.
+[[test]]
+name = "tap_dance_continues_behind_permissive_hold_key"
+behavior.morse.morses = [{ tap = "A", hold = "B", hold_after_tap = "C", double_tap = "D" }]
+steps = [
+  { tap = { pos = [1, 2], duration = 50 } },  # TD(0) tap: pattern "0", gap due at +250
+  { press = [1, 1] },                         # MT(B, LShift): unresolved, permissive hold
+  { press = [1, 2] },                         # TD(0) again, inside the gap
+  { delay = 300 },                            # MT hold, then TD(0) hold-after-tap
+  { release = [1, 2] },
+  { release = [1, 1] },
+]
+expect = [["LShift"], ["LShift", "C"], ["LShift"], []]
+
+
+# Same shape with a gap longer than the hold timeout: the re-press is due
+# before the first tap's gap, so a duplicate entry would be the one picked by
+# next_timeout, and its lone hold fires as B instead of the hold-after-tap
+# that the continued pattern resolves to.
+[[test]]
+name = "tap_dance_continues_behind_permissive_hold_key_short_hold"
+behavior.morse.profiles.p0 = { hold_timeout = "100ms", gap_timeout = "400ms" }
+behavior.morse.morses = [{ tap = "A", hold = "B", hold_after_tap = "C", double_tap = "D", profile = "p0" }]
+steps = [
+  { tap = { pos = [1, 2], duration = 50 } },  # TD(0) tap: pattern "0", gap due at +400
+  { press = [1, 1] },                         # MT(B, LShift): unresolved, hold due at +250
+  { press = [1, 2] },                         # TD(0) again, hold due at +100
+  { delay = 300 },                            # TD(0) hold-after-tap, then MT hold
+  { release = [1, 2] },
+  { release = [1, 1] },
+]
+expect = [["C"], ["C", "LShift"], ["LShift"], []]

--- a/rmk/tests/scenarios/one_shot.toml
+++ b/rmk/tests/scenarios/one_shot.toml
@@ -106,6 +106,34 @@ steps = [
 ]
 expect = [["LShift", "B"], []]
 
+# A tap-hold pressed inside the window keeps the OSM even if the deadline passes
+# while it is still unresolved. Regression: the expiry fired during that wait, so
+# the tap came out unshifted.
+[[test]]
+name = "osm_outlives_deadline_while_tap_hold_unresolved"
+behavior.one_shot = { timeout = "100ms" }
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },  # OSM(LShift), deadline at 110ms
+  { delay = 40 },
+  { press = [0, 3] },                         # TH(B, C) at 50ms, unresolved
+  { delay = 100 },                            # deadline passes at 110ms
+  { release = [0, 3] },                       # tap at 150ms
+]
+expect = [["LShift", "B"], []]
+
+# Same, resolved as a hold by its own timeout instead of a release.
+[[test]]
+name = "osm_outlives_deadline_while_tap_hold_unresolved_hold"
+behavior.one_shot = { timeout = "100ms" }
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },  # OSM(LShift), deadline at 110ms
+  { delay = 40 },
+  { press = [0, 3] },                         # TH(B, C) at 50ms, hold fires at 300ms
+  { delay = 300 },
+  { release = [0, 3] },
+]
+expect = [["LShift", "C"], []]
+
 # Two OSMs stack onto the same next key.
 [[test]]
 name = "osm_combined_modifiers"

--- a/rmk/tests/scenarios/user_hold.toml
+++ b/rmk/tests/scenarios/user_hold.toml
@@ -1,0 +1,49 @@
+# User-key hold gestures (5 s bond-clear etc.).
+#
+# The expiry is deadline-driven from `run()`: holding a profile key must not
+# park the keyboard task, so everything else keeps working during the hold.
+#
+# User keys aren't expressible in keymap TOML yet, so each case writes
+# `User(0)` into an unused board position over rynk first (a request is a
+# barrier, so the write is applied before the matrix input plays).
+#
+# Board positions used: (0,13) -> User(0), MouseWheelUp@(0,8), W@(1,3).
+
+keyboard = "boards/split.toml"
+
+features = ["_ble", "rynk"]
+
+[[test]]
+name = "held_user_key_does_not_stall_mouse_repeats"
+steps = [
+  { rynk = { cmd = "SetKeyAction", payload = { position = { layer = 0, row = 0, col = 13 }, action = { Single = { User = 0 } } } } },
+  { press = [0, 8] },   # Wheel down first: initial delta, repeats due at +100/+180ms
+  { delay = 20 },
+  { press = [0, 13] },  # Hold User(0): arms the 5s bond-clear deadline. No events
+                        # arrive while it's down, so only repeats fire meanwhile
+  { delay = 210 },      # covers two repeat ticks while the key stays held
+  { release = [0, 13] },
+  { release = [0, 8] },
+]
+expect = [
+  { mouse = { wheel = -1 } },
+  { mouse = { wheel = -1 } },  # repeat while the user key is held
+  { mouse = { wheel = -1 } },  # repeat
+  { mouse = {} },
+]
+
+# Any intervening key event cancels the hold gesture: typing over a held
+# profile key must not clear bonds, and the task must stay responsive.
+[[test]]
+name = "intervening_key_cancels_user_hold"
+steps = [
+  { rynk = { cmd = "SetKeyAction", payload = { position = { layer = 0, row = 0, col = 13 }, action = { Single = { User = 0 } } } } },
+  { press = [0, 13] },                        # Hold User(0)
+  { delay = 100 },
+  { tap = { pos = [1, 3], duration = 10 } },  # W: cancels the hold, reports promptly
+  { release = [0, 13] },
+  { delay = 2600 },                           # Past the would-be expiry: nothing fires
+  { delay = 2600 },
+  { tap = { pos = [1, 3], duration = 10 } },  # W again: keyboard still healthy
+]
+expect = [["W"], [], ["W"], []]

--- a/rmk/tests/scenarios/user_hold.toml
+++ b/rmk/tests/scenarios/user_hold.toml
@@ -3,23 +3,23 @@
 # The expiry is deadline-driven from `run()`: holding a profile key must not
 # park the keyboard task, so everything else keeps working during the hold.
 #
-# User keys aren't expressible in keymap TOML yet, so each case writes
-# `User(0)` into an unused board position over rynk first (a request is a
-# barrier, so the write is applied before the matrix input plays).
+# What a gesture sends the BLE profile task is asserted in
+# `tests/integration/ble_profile.rs`; these cases cover the timeline around it.
 #
-# Board positions used: (0,13) -> User(0), MouseWheelUp@(0,8), W@(1,3).
+# Board positions used: User0@(0,13), MouseWheelUp@(0,8), W@(1,3).
 
 keyboard = "boards/split.toml"
 
-features = ["_ble", "rynk"]
+features = ["_ble"]
 
+# Regression: the hold parked the keyboard task for its whole 5 s window,
+# freezing mouse repeats and every other timed behavior meanwhile.
 [[test]]
 name = "held_user_key_does_not_stall_mouse_repeats"
 steps = [
-  { rynk = { cmd = "SetKeyAction", payload = { position = { layer = 0, row = 0, col = 13 }, action = { Single = { User = 0 } } } } },
   { press = [0, 8] },   # Wheel down first: initial delta, repeats due at +100/+180ms
   { delay = 20 },
-  { press = [0, 13] },  # Hold User(0): arms the 5s bond-clear deadline. No events
+  { press = [0, 13] },  # Hold User0: arms the 5s bond-clear deadline. No events
                         # arrive while it's down, so only repeats fire meanwhile
   { delay = 210 },      # covers two repeat ticks while the key stays held
   { release = [0, 13] },
@@ -37,13 +37,11 @@ expect = [
 [[test]]
 name = "intervening_key_cancels_user_hold"
 steps = [
-  { rynk = { cmd = "SetKeyAction", payload = { position = { layer = 0, row = 0, col = 13 }, action = { Single = { User = 0 } } } } },
-  { press = [0, 13] },                        # Hold User(0)
+  { press = [0, 13] },                        # Hold User0
   { delay = 100 },
   { tap = { pos = [1, 3], duration = 10 } },  # W: cancels the hold, reports promptly
   { release = [0, 13] },
-  { delay = 2600 },                           # Past the would-be expiry: nothing fires
-  { delay = 2600 },
+  { delay = 5200 },                           # Past the would-be expiry
   { tap = { pos = [1, 3], duration = 10 } },  # W again: keyboard still healthy
 ]
 expect = [["W"], [], ["W"], []]


### PR DESCRIPTION
## Summary

`Keyboard::run()` races the event subscriber against a single earliest deadline instead of parking inside whichever wait came first, so every timed behavior (one-shot expiry, profile-key hold, buffered tap-hold and combo timeouts, mouse repeats) keeps firing while any other one is pending.

- `next_deadline()` / `fire_expired()` replace the nested waits and the 5 s `held_for_5s` block: the profile-key hold is a deadline, so the task stays responsive while the key is down.
- One-shot deadlines fold into `OneShotState::Single`.
- Combo shadow reset no longer sleeps 20 ms.
- Held-buffer timeouts race the earliest entry, and the timeout sorts nobody read are gone.
- A re-pressed morse key continues its buffered pattern instead of duplicating its entry.
- A one-shot stays armed while a buffered key waits on it, and a synthesized User-key tap (tap side of a tap-hold) disarms the hold instead of wiping the bond 5 s later.
- The simulator drains and records `BLE_PROFILE_CHANNEL`, so the 5 s hold path is tested end to end (`tests/integration/ble_profile.rs`).

## Behavior notes

- 5 s hold tie-break: the old `select` polled the timer first; `with_deadline` polls the subscriber first, so an event landing after the 5 s mark but before the task's next poll now cancels the gesture. The window is executor wake latency.
- Dropping the 20 ms sleep after a delayed combo output also dropped the minimum key-down for release-triggered combo output: a chord released within one scan now queues the output press and release back to back.
