### PR TITLE
fix(rynk): gate the KeyboardAction wire change

### DIFF
--- a/docs/docs/main/docs/development/rynk_protocol.md
+++ b/docs/docs/main/docs/development/rynk_protocol.md
@@ -5,7 +5,7 @@
 
 # Rynk Protocol Reference
 
-Current protocol version: **0.1**.
+Current protocol version: **1.0**.
 
 Every transport (USB vendor bulk, BLE GATT, BLE HID) carries the same frame — a 3-byte header plus a [postcard](https://docs.rs/postcard)-encoded payload:
 

--- a/rmk-types/src/protocol/rynk/payload/system.rs
+++ b/rmk-types/src/protocol/rynk/payload/system.rs
@@ -22,8 +22,7 @@ pub struct ProtocolVersion {
 
 impl ProtocolVersion {
     /// Current protocol version for this firmware release.
-    /// Now the protocol is still being developed, so the version is v0.1
-    pub const CURRENT: Self = Self { major: 0, minor: 1 };
+    pub const CURRENT: Self = Self { major: 1, minor: 0 };
 }
 
 /// Device capabilities discovered during the connection handshake.

--- a/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_frames.snap
@@ -55,7 +55,7 @@ GetPeripheralStatus reply Ok(PeripheralStatus{true,Available{Discharging,85}})  
 GetPeripheralStatus request 1                                                   05 04 08 01 01 00
 GetSleepState reply Ok(true)                                                    04 06 08 01 02 01 00
 GetSleepState request ()                                                        04 06 08 01 00
-GetVersion reply Ok(CURRENT)                                                    02 01 02 01 01 02 01 00
+GetVersion reply Ok(CURRENT)                                                    02 01 02 01 02 01 01 00
 GetVersion request ()                                                           02 01 02 01 00
 GetWpm reply Ok(42)                                                             04 05 08 01 02 2a 00
 GetWpm request ()                                                               04 05 08 01 00

--- a/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
+++ b/rmk-types/src/protocol/rynk/snapshots/wire_values.snap
@@ -10,6 +10,12 @@ Action::DefaultLayer(5)                   08 05
 Action::Key(Hid(A))                       01 00 04
 Action::KeyWithModifier(A,LShift)         03 04 02
 Action::KeyboardControl(Bootloader)       11 00
+Action::KeyboardControl(CapsWordToggle)   11 06
+Action::KeyboardControl(ClearEeprom)      11 02
+Action::KeyboardControl(ComboOff)         11 04
+Action::KeyboardControl(ComboOn)          11 03
+Action::KeyboardControl(ComboToggle)      11 05
+Action::KeyboardControl(Reboot)           11 01
 Action::LayerOff(3)                       06 03
 Action::LayerOn(1)                        04 01
 Action::LayerOnWithModifier(2,LCtrl)      05 02 01
@@ -65,7 +71,7 @@ ModifierCombination(LCtrl|RGui)           81
 MorseProfile(Normal,200,150)              c8 81 b0 89 0c
 Morse{TAP->Key(A)}                        00 01 02 01 00 04
 MouseButtons(B1|B8)                       81
-ProtocolVersion::CURRENT                  00 01
+ProtocolVersion::CURRENT                  01 00
 ProtocolVersion{1,0}                      01 00
 Result<(),RynkError>::Err(StorageFault)   01 02
 Result<(),RynkError>::Ok                  00

--- a/rmk-types/src/protocol/rynk/tests.rs
+++ b/rmk-types/src/protocol/rynk/tests.rs
@@ -347,11 +347,11 @@ fn exemplars() -> Exemplars {
 /// intentional, regenerate the snapshot and bump `ProtocolVersion::CURRENT`.
 ///
 /// One exemplar per Rynk wire type, plus every variant of the positional
-/// enums (`KeyAction`, `Action`, and the status enums) so a reordered or
-/// inserted variant flips the bytes. Postcard tags enums by declaration
-/// order, *not* the `#[repr]` discriminant, so the keycode exemplars also
-/// pin variant ordinals. Structs use distinct per-field values so a field
-/// swap is caught too. Only feature-independent values belong here: the
+/// enums (`KeyAction`, `Action`, its nested `KeyboardAction`, and the status
+/// enums) so a reordered or inserted variant flips the bytes. Postcard tags
+/// enums by declaration order, *not* the `#[repr]` discriminant, so the keycode
+/// exemplars also pin variant ordinals. Structs use distinct per-field values
+/// so a field swap is caught too. Only feature-independent values belong here: the
 /// gated `Action::Steno`, the `bulk` request/response payloads, and
 /// `PeripheralStatus` are excluded so every `rynk` feature set yields the
 /// same snapshot. Full frames are pinned separately in `wire_frames_locked`.
@@ -439,6 +439,30 @@ fn wire_values_locked() {
         (
             "Action::KeyboardControl(Bootloader)",
             encode(&Action::KeyboardControl(KeyboardAction::Bootloader)),
+        ),
+        (
+            "Action::KeyboardControl(Reboot)",
+            encode(&Action::KeyboardControl(KeyboardAction::Reboot)),
+        ),
+        (
+            "Action::KeyboardControl(ClearEeprom)",
+            encode(&Action::KeyboardControl(KeyboardAction::ClearEeprom)),
+        ),
+        (
+            "Action::KeyboardControl(ComboOn)",
+            encode(&Action::KeyboardControl(KeyboardAction::ComboOn)),
+        ),
+        (
+            "Action::KeyboardControl(ComboOff)",
+            encode(&Action::KeyboardControl(KeyboardAction::ComboOff)),
+        ),
+        (
+            "Action::KeyboardControl(ComboToggle)",
+            encode(&Action::KeyboardControl(KeyboardAction::ComboToggle)),
+        ),
+        (
+            "Action::KeyboardControl(CapsWordToggle)",
+            encode(&Action::KeyboardControl(KeyboardAction::CapsWordToggle)),
         ),
         (
             "Action::Special(GraveEscape)",

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bump the Rynk protocol to 1.0 after removing unused `KeyboardAction` variants changed the serialized key-action format, so mismatched hosts and firmware are rejected instead of interpreting the same bytes as different actions
 - Fix UTF-8 panics when non-ASCII names are used in `keyboard.toml` aliases, and accept Unicode whitespace between keymap actions
 - Honour `SET_PROTOCOL` on the boot-subclass keyboard interface. v0.9.0 advertises the boot keyboard protocol in the descriptor, but the device rejected the switch to boot mode and `GET_PROTOCOL` always answered report mode, so a host that requires the switch before using the keyboard — a BIOS/UEFI setup screen, a KVM switch, a BMC — could be left without a working keyboard. The keyboard interface now accepts both modes and reports the selected one
 


### PR DESCRIPTION
## Problem

#1103 removed four unused `KeyboardAction` variants from the middle of a postcard-serialized enum. That renumbered every following action while both host and firmware still advertised Rynk protocol 0.1.

For example, a current host serializes `ComboOn` with inner tag 3, which a 0.1 firmware from before #1103 decodes as `ClearEeprom`. Traffic in the other direction is rejected or decoded differently, but the same-major handshake permits the session.

## Fix

- bump the breaking Rynk wire version from 0.1 to 1.0 so mismatched peers are rejected during the handshake
- snapshot every current nested `KeyboardAction` ordinal, rather than only `Bootloader`
- regenerate the wire snapshots and protocol reference
- document the compatibility fix in the changelog

## Verification

- `cargo test --features host` in `rmk-types`: 77 passed
- `cargo test --all-features` in `rynk`: 80 passed across unit/integration crates
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` in `rmk`: 502 passed
- `cargo test` in `rmk-config`: 109 passed
- `cargo check --no-default-features --features=dongle,display,_ble` in `rmk`
- `bash scripts/format_all.sh`
