### PR TITLE
fix(keymap): preserve transparent release layer

### DIFF
--- a/rmk/src/keymap.rs
+++ b/rmk/src/keymap.rs
@@ -239,6 +239,8 @@ impl KeyMapInner<'_> {
             }
         }
 
+        // Keep release on the same transparent default-layer action as press.
+        self.save_layer_cache(event.pos, self.behavior.default_layer);
         KeyAction::No
     }
 

--- a/rmk/tests/scenarios/layer.toml
+++ b/rmk/tests/scenarios/layer.toml
@@ -22,3 +22,13 @@ steps = [
   { tap = { pos = [0, 11], duration = 10 } },
 ]
 expect = [["A"], [], ["B"], []]
+
+# After PDF(1), (3,2) is transparent on the default layer. Its release must
+# not fall back to layer 0's A action and emit a stray all-up report.
+[[test]]
+name = "transparent_default_layer_key_has_no_release_action"
+steps = [
+  { tap = { pos = [0, 10], duration = 10 } },
+  { tap = { pos = [3, 2], duration = 10 } },
+  { no_report = 100 },
+]


### PR DESCRIPTION
## Problem

After the default layer changes above layer 0, a key that is transparent on every active/default layer resolves to No on press without updating its layer cache. On release, the zero-initialized cache points at layer 0, so RMK processes the unrelated layer-0 release action. The regression case observes a stray all-up HID report; stateful layer-0 actions can also apply an unmatched release.

## Fix

Cache the current default layer when transparent lookup reaches No. Release then resolves the same transparent no-op action as press.

## Evidence

The new end-to-end scenario fails on origin/main with:

    expect[0]: unexpected HID report []

It passes with the cache update.

## Tests

- cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble transparent_default_layer_key_has_no_release_action
- cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble (503 passed)
- cargo nextest run --no-default-features --features=rynk,_ble,split,async_matrix,storage --test integration transparent_default_layer_key_has_no_release_action
- sh scripts/format_all.sh

## Risk

Low. The only runtime change records the default layer for a press that already resolved to No because every eligible action was transparent. The release therefore becomes Transparent instead of reading an unrelated stale layer-0 cache entry.