### PR TITLE
fix(storage): wait on a flush barrier instead of a shared write signal

### DIFF
--- a/rmk/src/ble/profile.rs
+++ b/rmk/src/ble/profile.rs
@@ -6,12 +6,12 @@ use embassy_futures::select::{Either3, select3};
 use embassy_sync::signal::Signal;
 use trouble_host::prelude::*;
 use trouble_host::{BondInformation, LongTermKey};
-#[cfg(feature = "storage")]
-use {crate::channel::FLASH_CHANNEL, crate::storage::FLASH_OPERATION_FINISHED};
 
 use super::ble_server::CCCD_TABLE_SIZE;
 use crate::NUM_BLE_PROFILE;
 use crate::channel::BLE_PROFILE_CHANNEL;
+#[cfg(feature = "storage")]
+use crate::channel::FLASH_CHANNEL;
 use crate::state::{current_profile, set_ble_profile};
 
 pub(crate) static UPDATED_PROFILE: Signal<crate::RawMutex, ProfileInfo> = Signal::new();
@@ -310,8 +310,7 @@ where
     /// Wait for profile switch event and update active profile
     ///
     /// This function will wait for profile switch operation, then update the active profile
-    /// based on the operation type. After completing the operation, it will wait for a period
-    /// to ensure the flash operation is completed.
+    /// based on the operation type, and return once the profile write has landed.
     pub(crate) async fn update_profile(&mut self) {
         // Wait for profile switch or updated profile event
         loop {
@@ -323,8 +322,6 @@ where
             .await
             {
                 Either3::First(action) => {
-                    #[cfg(feature = "storage")]
-                    FLASH_OPERATION_FINISHED.reset();
                     match action {
                         BleProfileAction::Switch(profile) => {
                             if !self.switch_profile(profile).await {
@@ -358,7 +355,7 @@ where
                         }
                     }
                     #[cfg(feature = "storage")]
-                    FLASH_OPERATION_FINISHED.wait().await;
+                    crate::storage::flush().await;
                     info!("Update profile done");
                     break;
                 }

--- a/rmk/src/storage/mod.rs
+++ b/rmk/src/storage/mod.rs
@@ -28,9 +28,17 @@ use crate::config::StorageConfig;
 use crate::split::ble::PeerAddress;
 use crate::{BUILD_HASH, config};
 
-/// Signal to synchronize the flash operation status, usually used outside of the flash task.
-/// True if the flash operation is finished correctly, false if the flash operation is finished with error.
-pub(crate) static FLASH_OPERATION_FINISHED: Signal<crate::RawMutex, bool> = Signal::new();
+/// Reply to a `Flush` request: `false` if a write failed since the previous flush.
+static FLUSHED: Signal<crate::RawMutex, bool> = Signal::new();
+
+/// Wait until every write queued before this call has been processed.
+/// Returns `false` if any write failed since the previous flush.
+/// `FLUSHED` has a single waiter slot, so calls must not overlap.
+pub(crate) async fn flush() -> bool {
+    FLUSHED.reset();
+    FLASH_CHANNEL.send(FlashOperationMessage::Flush).await;
+    FLUSHED.wait().await
+}
 
 // Request/response over `FLASH_CHANNEL`. One `Signal` per read variant; the
 // storage task fires the matching one once it has the result.
@@ -74,13 +82,12 @@ pub(crate) async fn read_active_ble_profile() -> Option<u8> {
     .await
 }
 
-/// Send a peer address to be persisted; wait for the storage task to finish.
+/// Persist a peer address and wait for it to land.
 /// Returns `true` if the write completed successfully.
 #[cfg(all(feature = "_ble", feature = "split"))]
 pub(crate) async fn write_peer_address(addr: PeerAddress) -> bool {
-    FLASH_OPERATION_FINISHED.reset();
     FLASH_CHANNEL.send(FlashOperationMessage::PeerAddress(addr)).await;
-    FLASH_OPERATION_FINISHED.wait().await
+    flush().await
 }
 
 // Message send from other tasks, which will do saving or clearing operation
@@ -168,6 +175,8 @@ pub(crate) enum FlashOperationMessage {
     #[cfg(feature = "_ble")]
     // Read the persisted active BLE profile number; storage task replies via `ACTIVE_BLE_PROFILE_RESPONSE`.
     ReadActiveBleProfile,
+    // Barrier: storage task replies via `FLUSHED` once every earlier message is processed.
+    Flush,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -658,11 +667,17 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
     crate::core_traits::Runnable for Storage<F, ROW, COL, NUM_LAYER, NUM_ENCODER>
 {
     async fn run(&mut self) -> ! {
+        let mut failed = false;
         loop {
             let info: FlashOperationMessage = FLASH_CHANNEL.receive().await;
             debug!("Flash operation: {:?}", info);
 
             let write_result: Result<(), SSError<F::Error>> = match info {
+                FlashOperationMessage::Flush => {
+                    FLUSHED.signal(!failed);
+                    failed = false;
+                    continue;
+                }
                 #[cfg(feature = "_ble")]
                 FlashOperationMessage::ReadBleBondInfo(slot_num) => {
                     let resp = match self.fetch_data(StorageKey::bond_info(slot_num)).await {
@@ -821,12 +836,9 @@ impl<F: AsyncNorFlash, const ROW: usize, const COL: usize, const NUM_LAYER: usiz
                 }
             };
 
-            match write_result {
-                Ok(()) => FLASH_OPERATION_FINISHED.signal(true),
-                Err(e) => {
-                    print_storage_error::<F>(e);
-                    FLASH_OPERATION_FINISHED.signal(false);
-                }
+            if let Err(e) = write_result {
+                print_storage_error::<F>(e);
+                failed = true;
             }
         }
     }
@@ -1007,6 +1019,38 @@ mod tests {
             assert_eq!(decoded, key);
             assert_eq!(used, size);
         }
+    }
+
+    #[cfg(all(feature = "_ble", feature = "split"))]
+    #[test]
+    fn peer_address_write_waits_for_its_own_flush() {
+        use core::future::Future;
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+
+        let mut cx = Context::from_waker(Waker::noop());
+        FLASH_CHANNEL.clear();
+        FLUSHED.reset();
+        FLASH_CHANNEL
+            .try_send(FlashOperationMessage::LayoutOptions(42))
+            .unwrap();
+
+        let mut write = pin!(write_peer_address(PeerAddress::new(0, true, [1; 6])));
+        assert!(matches!(write.as_mut().poll(&mut cx), Poll::Pending));
+
+        // The storage task sees the older write, the peer address, then the barrier.
+        assert!(matches!(
+            FLASH_CHANNEL.try_receive(),
+            Ok(FlashOperationMessage::LayoutOptions(42))
+        ));
+        assert!(matches!(
+            FLASH_CHANNEL.try_receive(),
+            Ok(FlashOperationMessage::PeerAddress(_))
+        ));
+        assert!(matches!(write.as_mut().poll(&mut cx), Poll::Pending));
+        assert!(matches!(FLASH_CHANNEL.try_receive(), Ok(FlashOperationMessage::Flush)));
+        FLUSHED.signal(true);
+        assert!(matches!(write.as_mut().poll(&mut cx), Poll::Ready(true)));
     }
 
     #[test]

--- a/rmk/src/test_support.rs
+++ b/rmk/src/test_support.rs
@@ -34,13 +34,8 @@ pub fn clear_flash_channel() {
 }
 
 #[cfg(feature = "storage")]
-pub fn reset_flash_operation() {
-    crate::storage::FLASH_OPERATION_FINISHED.reset();
-}
-
-#[cfg(feature = "storage")]
-pub async fn flash_operation_finished() -> bool {
-    crate::storage::FLASH_OPERATION_FINISHED.wait().await
+pub async fn flush_storage() -> bool {
+    crate::storage::flush().await
 }
 
 const STEP: Duration = Duration::from_micros(100);

--- a/rmk/tests/integration/simulator/mod.rs
+++ b/rmk/tests/integration/simulator/mod.rs
@@ -458,8 +458,6 @@ async fn run_steps(steps: Vec<SimStep>, to_device: &Link, from_device: &Link) {
                 }
             }
             SimStep::HostSend(request) => {
-                #[cfg(feature = "storage")]
-                rmk::test_support::reset_flash_operation();
                 let blocked = format!(
                     "host request of {} bytes blocked for {TIMEOUT_SECS}s: {}",
                     request.len(),
@@ -509,7 +507,7 @@ async fn run_steps(steps: Vec<SimStep>, to_device: &Link, from_device: &Link) {
             #[cfg(feature = "storage")]
             SimStep::WaitStorage => {
                 let waiting = format!("no storage write within {TIMEOUT_SECS}s");
-                let written = with_timeout(rmk::test_support::flash_operation_finished(), &waiting).await;
+                let written = with_timeout(rmk::test_support::flush_storage(), &waiting).await;
                 assert!(written, "storage write failed");
             }
             #[cfg(feature = "passkey_entry")]


### PR DESCRIPTION
## Problem

`FLASH_CHANNEL.send` completes when a write is queued, but the storage task signalled one shared `FLASH_OPERATION_FINISHED` after every write. If an older, unrelated write was still queued, `write_peer_address` or a BLE profile switch could consume that older completion and return before its own write had run. This reported success for a write that had not happened yet, or hid its later failure.

## Fix

Writes no longer signal anything. A caller that needs its write to land sends a `Flush` marker behind it and waits for the reply through `storage::flush()`. `FLASH_CHANNEL` is FIFO, so the marker is answered only after every earlier message is processed. The reply is `false` if any write failed since the previous flush.

- `FLASH_OPERATION_FINISHED` is removed; the `Flush` variant and `flush()` replace it.
- `write_peer_address` is send + `flush()`; `update_profile` calls `flush()` where the reset/wait pair was.
- The simulator's `WaitStorage` step is a `flush()`, and `HostSend` no longer resets anything.

At most one write-awaiter exists per device (the split peripheral's `write_peer_address`, the BLE task's `update_profile`, and the simulator are mutually exclusive), which is the same single-waiter constraint the existing read-response signals already rely on.

## Evidence

`peer_address_write_waits_for_its_own_flush` drives the channel by hand: with an unrelated `LayoutOptions` write queued first, the peer-address future stays pending after both writes are dequeued and completes only when its `Flush` marker is answered.

## Tests

- `cargo nextest run --no-default-features --features=rynk,_ble,split,async_matrix,storage` (556 passed)
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` (503 passed)
- `cargo check --no-default-features`, and with `dongle,_ble,storage`, `dongle,vial,_ble,storage`, `split,_ble,storage`
- nightly rustfmt

## Risk

Low. Only internal storage completion routing changes. Awaited operations now wait until every write queued ahead of them has landed, which is the documented contract. `flush()` can report an earlier unrelated failure; callers treat that as their own write failing, so the peripheral simply re-saves the central address on the next connection.
