### PR TITLE
fix(ble): enforce the identity string limits at compile time

### DIFF
--- a/rmk-macro/src/codegen/orchestrator.rs
+++ b/rmk-macro/src/codegen/orchestrator.rs
@@ -5,6 +5,7 @@ use rmk_config::resolved::hardware::{
     BoardConfig, ChipSeries, KeyInfo, MatrixConfig, MatrixType, UniBodyConfig,
 };
 use rmk_config::resolved::{Behavior, Hardware, Host, Identity, Keymap, Layout};
+use rmk_types::ble::{BLE_ADV_NAME_MAX_LEN, BLE_DIS_STRING_MAX_LEN};
 
 use super::behavior::expand_behavior_config;
 use super::chip::bind_interrupt::expand_bind_interrupt;
@@ -64,6 +65,22 @@ pub(crate) fn parse_keyboard_mod(item_mod: syn::ItemMod) -> TokenStream2 {
         host.rynk_enabled,
     )
     .unwrap_or_else(|err| panic!("{err}"));
+
+    // Over-budget strings would leave the keyboard undiscoverable or panic it on boot.
+    let name_len = identity.product_name.len();
+    let vendor_len = identity.manufacturer.len();
+    let serial_len = identity.serial_number.as_ref().map_or(0, String::len);
+    for (field, len, max) in [
+        ("product_name", name_len, BLE_ADV_NAME_MAX_LEN),
+        ("manufacturer", vendor_len, BLE_DIS_STRING_MAX_LEN),
+        ("serial_number", serial_len, BLE_DIS_STRING_MAX_LEN),
+    ] {
+        if hardware.communication.ble_enabled() && len > max {
+            let msg =
+                format!("keyboard.toml: `{field}` is {len} bytes, but BLE fits at most {max}.");
+            return quote! { compile_error!(#msg); };
+        }
+    }
 
     // Generate imports and statics
     let imports_and_statics =

--- a/rmk-types/src/ble.rs
+++ b/rmk-types/src/ble.rs
@@ -1,7 +1,14 @@
-//! BLE status types.
+//! BLE status types and the limits an identity string has to clear.
 
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
+
+/// Longest name a legacy advertisement can carry: flags (3), the battery + HID service
+/// UUIDs (6) and the appearance (4) claim the rest of its 31 bytes.
+pub const BLE_ADV_NAME_MAX_LEN: usize = 16;
+
+/// Capacity of a Device Information Service string, in static RAM whatever it holds.
+pub const BLE_DIS_STRING_MAX_LEN: usize = 24;
 
 /// BLE state (what the BLE subsystem is currently doing).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, MaxSize)]

--- a/rmk/src/ble/adv.rs
+++ b/rmk/src/ble/adv.rs
@@ -128,6 +128,8 @@ pub(crate) async fn advertise<'a, 'b, C: Controller, const ATT: usize, const CON
 
 #[cfg(test)]
 mod tests {
+    use rmk_types::ble::BLE_ADV_NAME_MAX_LEN;
+
     use super::Adv;
 
     /// Overrunning the 31-byte legacy advertisement only fails at runtime.
@@ -139,10 +141,10 @@ mod tests {
     fn every_advertisement_fits_the_legacy_budget() {
         assert!(fits(Adv::SplitPeripheral { id: 0xFF }));
         assert!(fits(Adv::DongleSeeking));
-        // Flags, UUIDs and appearance leave 16 bytes for the name.
-        assert!(fits(Adv::Host {
-            name: "0123456789abcdef"
-        }));
+        // Where BLE_ADV_NAME_MAX_LEN comes from: this name fills the budget exactly.
+        const LONGEST_NAME: &str = "0123456789abcdef";
+        assert_eq!(LONGEST_NAME.len(), BLE_ADV_NAME_MAX_LEN);
+        assert!(fits(Adv::Host { name: LONGEST_NAME }));
         assert!(!fits(Adv::Host {
             name: "0123456789abcdefg"
         }));

--- a/rmk/src/ble/device_info.rs
+++ b/rmk/src/ble/device_info.rs
@@ -1,4 +1,8 @@
+use rmk_types::ble::BLE_DIS_STRING_MAX_LEN;
 use trouble_host::prelude::*;
+
+// The one string RMK supplies itself; `rmk_macro` rejects over-long ones from keyboard.toml.
+const _: () = core::assert!(crate::config::RMK_BUILD_INFO.len() <= BLE_DIS_STRING_MAX_LEN);
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
@@ -48,7 +52,7 @@ pub(crate) struct DeviceConfigurationService {
         read,
         value = heapless::String::try_from("vial:f64c2b3c:000001").unwrap()
     )]
-    pub(crate) serial_number: heapless::String<20>,
+    pub(crate) serial_number: heapless::String<BLE_DIS_STRING_MAX_LEN>,
     #[characteristic(uuid = "2a29", read)]
-    pub(crate) manufacturer_name: heapless::String<20>,
+    pub(crate) manufacturer_name: heapless::String<BLE_DIS_STRING_MAX_LEN>,
 }

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -239,21 +239,16 @@ async fn run_ble_keyboard<
             },
         )
         .unwrap();
-    // The serial number characteristic is length limited, so truncate at a char
-    // boundary instead of panicking when the configured serial is too long.
-    let mut serial_number_trimmed = heapless::String::new();
-    for c in serial_number.chars() {
-        if serial_number_trimmed.push(c).is_err() {
-            break;
-        }
-    }
     server
-        .set(&server.device_config_service.serial_number, &serial_number_trimmed)
+        .set(
+            &server.device_config_service.serial_number,
+            &heapless::String::try_from(serial_number).expect("serial_number is too long for BLE"),
+        )
         .unwrap();
     server
         .set(
             &server.device_config_service.manufacturer_name,
-            &heapless::String::try_from(device_config.manufacturer).unwrap(),
+            &heapless::String::try_from(device_config.manufacturer).expect("manufacturer is too long for BLE"),
         )
         .unwrap();
     let server = &server;


### PR DESCRIPTION
An over-long `product_name` left a BLE keyboard advertising nothing; `rmk-macro` now rejects it in `keyboard.toml` and a const assert pins the default serial, so no truncation code ships.