### PR TITLE
fix(keyboard): re-activate caps word when toggled after the timeout

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -98,9 +98,10 @@ impl CapsWordState {
 
     /// Toggle Caps Word
     fn toggle(&mut self) {
-        match self {
-            CapsWordState::Activated { .. } => self.deactivate(),
-            CapsWordState::Deactivated => self.activate(),
+        if self.is_active() {
+            self.deactivate();
+        } else {
+            self.activate();
         }
     }
 

--- a/rmk/tests/scenarios/caps_word.toml
+++ b/rmk/tests/scenarios/caps_word.toml
@@ -1,0 +1,39 @@
+# Caps Word shifts letters until a non-continuation key or 5 s of idle time,
+# on a two-key board of its own: CapsWordToggle@(0,0), A@(0,1).
+
+[layout]
+rows = 1
+cols = 2
+map = "(0,0)  (0,1)"
+
+[[keymap.layer]]
+keys = "CapsWordToggle  A"
+
+[[test]]
+name = "caps_word_shifts_letters"
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },
+  { tap = { pos = [0, 1], duration = 10 } },
+]
+expect = [
+  ["LShift", "A"],
+  [],
+]
+
+# The 5 s timeout leaves the state machine activated-but-inactive, so the next
+# press of the Caps Word key has to switch it back on rather than off.
+[[test]]
+name = "caps_word_reactivates_after_the_timeout"
+steps = [
+  { tap = { pos = [0, 0], duration = 10 } },
+  { tap = { pos = [0, 1], duration = 10 } },
+  { delay = 6000 },
+  { tap = { pos = [0, 0], duration = 10 } },
+  { tap = { pos = [0, 1], duration = 10 } },
+]
+expect = [
+  ["LShift", "A"],
+  [],
+  ["LShift", "A"],
+  [],
+]


### PR DESCRIPTION
After Caps Word times out, the first press to turn it back on does nothing, so you need to press it twice.

Repro: turn Caps Word on, type a letter, wait more than five seconds, then press Caps Word and type another letter.

The timeout deliberately leaves `CapsWordState` on `Activated` - its doc comment says "activated (but may have timed out thus becoming inactive)". Only `is_active()` checks the clock, but `toggle()` matched the variant, so that first press called `deactivate()` on a feature thats already off.

There was no `caps_word.toml`, so Caps Word had no behavioural coverage. The new 39-line scenario file covers shifting a letter and toggling back on after the timeout. The timeout case failed before with expected `["LShift", "A"]` and actual `["A"]`.

I didnt add a case for toggling it off again before the timeout.
