### PR TITLE
feat(vial): make macro count configurable

### DIFF
--- a/docs/docs/main/docs/configuration/appendix.md
+++ b/docs/docs/main/docs/configuration/appendix.md
@@ -576,6 +576,8 @@ defmt_log = true
 [host]
 # Whether Vial is enabled (default: true in keyboard.toml config)
 vial_enabled = true
+# Number of dynamic macro slots reported to Vial (default: 32).
+vial_macro_count = 32
 # Whether Rynk is enabled (experimental, default: false in keyboard.toml config)
 # Rynk and Vial are mutually exclusive and must match Cargo features.
 rynk_enabled = false

--- a/docs/docs/main/docs/configuration/host_config.md
+++ b/docs/docs/main/docs/configuration/host_config.md
@@ -4,6 +4,7 @@ The `[host]` section selects the firmware protocol used by host-side tools.
 RMK currently supports two mutually exclusive protocols:
 
 - `vial_enabled`: the Vial/VIA-compatible protocol for the Vial app. This is the default.
+- `vial_macro_count`: the number of dynamic macro slots reported to Vial. It defaults to 32 and is independent of `rmk.macro_space_size`.
 - `rynk_enabled`: RMK's native protocol for RMK-aware host tools. **Experimental** — see
   [Rynk](../features/rynk).
 
@@ -44,6 +45,7 @@ Use Vial with the `rmk` default Cargo features:
 [host]
 vial_enabled = true
 rynk_enabled = false
+vial_macro_count = 32
 unlock_keys = [[0, 0], [0, 1]]
 ```
 

--- a/rmk-config/src/lib.rs
+++ b/rmk-config/src/lib.rs
@@ -1111,6 +1111,9 @@ pub(crate) struct HostConfig {
     /// Whether Vial is enabled
     #[serde_inline_default(true)]
     pub vial_enabled: bool,
+    /// Number of dynamic macros reported to Vial.
+    #[serde_inline_default(32)]
+    pub vial_macro_count: u8,
     /// Whether the RMK-native Rynk protocol is enabled. Mutually exclusive
     /// with `vial_enabled` (the underlying Cargo features conflict).
     #[serde_inline_default(false)]
@@ -1133,6 +1136,7 @@ impl Default for HostConfig {
     fn default() -> Self {
         Self {
             vial_enabled: true,
+            vial_macro_count: 32,
             rynk_enabled: false,
             unlock_keys: None,
             insecure: false,
@@ -1532,6 +1536,30 @@ fork_max_num = 255
             let err = toml::from_str::<KeyboardTomlConfig>(&toml).unwrap_err();
             assert!(err.to_string().contains(message), "{err}");
         }
+    }
+
+    #[test]
+    fn vial_macro_count_defaults_and_accepts_override() {
+        let default: KeyboardTomlConfig = toml::from_str("").unwrap();
+        assert_eq!(default.host().vial_macro_count, 32);
+
+        let configured: KeyboardTomlConfig = toml::from_str(
+            r#"
+[host]
+vial_macro_count = 1
+"#,
+        )
+        .unwrap();
+        assert_eq!(configured.host().vial_macro_count, 1);
+
+        let err = toml::from_str::<KeyboardTomlConfig>(
+            r#"
+[host]
+vial_macro_count = 256
+"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("vial_macro_count"), "{err}");
     }
 
     #[test]

--- a/rmk-config/src/resolved/host.rs
+++ b/rmk-config/src/resolved/host.rs
@@ -3,6 +3,7 @@ use crate::validate_unlock_keys;
 /// Resolved host-tool configuration.
 pub struct Host {
     pub vial_enabled: bool,
+    pub vial_macro_count: u8,
     pub rynk_enabled: bool,
     pub unlock_keys: Vec<[u8; 2]>,
     pub insecure: bool,
@@ -20,6 +21,7 @@ impl crate::KeyboardTomlConfig {
 
         Host {
             vial_enabled: host_toml.vial_enabled,
+            vial_macro_count: host_toml.vial_macro_count,
             rynk_enabled: host_toml.rynk_enabled,
             unlock_keys,
             insecure: host_toml.insecure,

--- a/rmk-macro/src/codegen/keyboard_config.rs
+++ b/rmk-macro/src/codegen/keyboard_config.rs
@@ -61,6 +61,7 @@ pub(crate) fn expand_vial_config(host: &Host) -> proc_macro2::TokenStream {
     }
     let unlock_keys = unlock_keys_tokens(host);
     let insecure = host.insecure;
+    let macro_count = host.vial_macro_count;
     quote! {
         include!(concat!(env!("OUT_DIR"), "/config_generated.rs"));
         const VIAL_CONFIG: ::rmk::config::VialConfig = ::rmk::config::VialConfig {
@@ -68,6 +69,7 @@ pub(crate) fn expand_vial_config(host: &Host) -> proc_macro2::TokenStream {
             vial_keyboard_def: &VIAL_KEYBOARD_DEF,
             unlock_keys: #unlock_keys,
             insecure: #insecure,
+            macro_count: #macro_count,
         };
     }
 }

--- a/rmk/src/config/vial.rs
+++ b/rmk/src/config/vial.rs
@@ -1,12 +1,14 @@
 /// Config for [vial](https://get.vial.today/).
 ///
 /// You can generate automatically using [`build.rs`](https://github.com/rmk-rs/rmk/blob/main/examples/use_rust/stm32h7/build.rs).
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct VialConfig<'a> {
     pub vial_keyboard_id: &'a [u8],
     pub vial_keyboard_def: &'a [u8],
     pub unlock_keys: &'a [(u8, u8)],
     pub insecure: bool,
+    /// Number of dynamic macros reported to Vial.
+    pub macro_count: u8,
 }
 
 impl<'a> VialConfig<'a> {
@@ -16,6 +18,25 @@ impl<'a> VialConfig<'a> {
             vial_keyboard_def,
             unlock_keys,
             insecure: false,
+            macro_count: 32,
+        }
+    }
+
+    /// Set the number of dynamic macros reported to Vial.
+    pub const fn with_macro_count(mut self, macro_count: u8) -> Self {
+        self.macro_count = macro_count;
+        self
+    }
+}
+
+impl Default for VialConfig<'_> {
+    fn default() -> Self {
+        Self {
+            vial_keyboard_id: &[],
+            vial_keyboard_def: &[],
+            unlock_keys: &[],
+            insecure: false,
+            macro_count: 32,
         }
     }
 }

--- a/rmk/src/host/via/mod.rs
+++ b/rmk/src/host/via/mod.rs
@@ -147,8 +147,7 @@ impl<'a> VialService<'a> {
                 boot::jump_to_bootloader();
             }
             ViaCommand::DynamicKeymapMacroGetCount => {
-                report.input_data[1] = 32;
-                warn!("Macro get count -- to be implemented")
+                report.input_data[1] = self.vial_config.macro_count;
             }
             ViaCommand::DynamicKeymapMacroGetBufferSize => {
                 report.input_data[1] = (MACRO_SPACE_SIZE as u16 >> 8) as u8;
@@ -301,6 +300,26 @@ mod tests {
             input_data: output_data,
             output_data,
         }
+    }
+
+    #[test]
+    fn macro_count_uses_vial_config() {
+        let mut data = KeymapData::new([[[KeyAction::No]]]);
+        let mut behavior = BehaviorConfig::default();
+        let positional = PositionalConfig::<1, 1>::default();
+        let keymap = block_on(KeyMap::new(&mut data, &mut behavior, &positional));
+        let mut config = RmkConfig::default();
+        config.vial_config = VialConfig::new(&[], &[], &[]).with_macro_count(1);
+        let service = VialService::new(&keymap, &config);
+        let mut report = ViaReport {
+            input_data: [0; 32],
+            output_data: [0; 32],
+        };
+        report.output_data[0] = ViaCommand::DynamicKeymapMacroGetCount as u8;
+
+        block_on(service.process_via_packet(&mut report));
+
+        assert_eq!(report.input_data[1], 1);
     }
 
     // `output_data` is [u8; 32], so the handler slices `output_data[4..4 + size]`.


### PR DESCRIPTION
## Summary

Make the dynamic macro count reported by the Vial protocol configurable instead of always returning 32.

- adds `VialConfig::macro_count` with a backwards-compatible default of 32;
- adds `VialConfig::with_macro_count()` for Rust-configured keyboards;
- adds `[host].vial_macro_count` for `keyboard.toml` users;
- wires the resolved value through `rmk-macro` code generation;
- returns the configured value from `DynamicKeymapMacroGetCount` (`0x0c`).

`vial_macro_count` is deliberately independent of `rmk.macro_space_size`: one controls the number of slots exposed to Vial, while the other controls their total byte storage.

## Validation

- `rmk-config`: 102 unit tests and 8 keyboard TOML validation tests passed;
- `rmk-macro`: 65 unit tests and the compile-fail suite passed;
- exact Vial protocol test passed with `macro_count = 1`;
- `cargo check` passed for `vial,host_lock,storage`;
- Clippy passed with `-D warnings` for `rmk`, `rmk-config`, and `rmk-macro`.

The default remains 32, so existing `VialConfig::new(...)`, `VialConfig::default()`, and `keyboard.toml` configurations preserve the previous wire behavior.
