### PR TITLE
fix(combo): preserve disjoint timeout windows

### DIFF
--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -360,22 +360,20 @@ impl<'a> Keyboard<'a> {
                 timeout_event.pressed = false;
                 self.trigger_delayed_combo(&key.action, timeout_event).await;
 
-                if self
+                if let Some(key) = self
                     .held_buffer
                     .remove_if(|k| k.event.pos == key.event.pos && k.state == KeyState::WaitingCombo)
-                    .is_none()
                 {
-                    return;
+                    self.keymap.with_combos_mut(|combos| {
+                        combos
+                            .iter_mut()
+                            .flatten()
+                            .filter(|combo| !combo.is_triggered() && combo.config.contains(&key.action))
+                            .for_each(Combo::reset);
+                    });
+                    self.process_key_action(&key.action, key.event, false, key.press_time)
+                        .await;
                 }
-                self.keymap.with_combos_mut(|combos| {
-                    combos
-                        .iter_mut()
-                        .filter_map(|combo| combo.as_mut())
-                        .filter(|combo| !combo.is_triggered() && combo.config.contains(&key.action))
-                        .for_each(Combo::reset);
-                });
-                self.process_key_action(&key.action, key.event, false, key.press_time)
-                    .await;
             }
             _ => {
                 debug!("Buffered morse key timeout");

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -354,7 +354,7 @@ impl<'a> Keyboard<'a> {
         match key.state {
             KeyState::WaitingCombo => {
                 debug!("[Combo] Timeout, dispatch combo");
-                self.dispatch_combos(&key.action, key.event).await;
+                self.dispatch_combos(&key.action, key.event, false).await;
             }
             _ => {
                 debug!("Buffered morse key timeout");
@@ -1004,7 +1004,8 @@ impl<'a> Keyboard<'a> {
     /// - `key_action`: The action of the key that triggered this function
     /// - `event`: The keyboard event. When pressing (interrupting), trigger any delayed combo.
     ///   When releasing, only trigger combos that contain the key_action.
-    async fn trigger_delayed_combo(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
+    /// - `interrupting_press`: Whether this is a new press rather than a buffered press timing out.
+    async fn trigger_delayed_combo(&mut self, key_action: &KeyAction, event: KeyboardEvent, interrupting_press: bool) {
         // First, find the delayed combo and trigger it
         let triggered_combo = self.keymap.with_combos_mut(|combos| {
             combos
@@ -1014,7 +1015,7 @@ impl<'a> Keyboard<'a> {
                     if c.is_all_pressed() && !c.is_triggered() {
                         // When a key is pressed (interrupting a combo wait), trigger any delayed combo.
                         // When releasing a key, only trigger combos that contain the key_action.
-                        if event.pressed || c.config.contains(key_action) {
+                        if interrupting_press || c.config.contains(key_action) {
                             // All keys are pressed but the combo is not triggered, trigger it
                             return Some((c.size(), c));
                         }
@@ -1075,7 +1076,7 @@ impl<'a> Keyboard<'a> {
 
         // First, when releasing a key, check whether there's untriggered combo, if so, triggerer it first
         if !event.pressed {
-            self.trigger_delayed_combo(key_action, event).await;
+            self.trigger_delayed_combo(key_action, event, false).await;
         }
 
         // If this is a re-press of a key belonging to an already-triggered combo
@@ -1201,14 +1202,32 @@ impl<'a> Keyboard<'a> {
             }
 
             // When no key is updated(the combo is interruptted), or a key is released,
-            self.dispatch_combos(key_action, event).await;
+            self.dispatch_combos(key_action, event, true).await;
             (Some(*key_action), false)
         }
     }
 
-    // Dispatch combo keys buffered in the held buffer when the combo isn't being triggered.
-    async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
-        self.trigger_delayed_combo(key_action, event).await;
+    // Dispatch all waiting combo keys after an event interruption, or only the
+    // expired key when called by the deadline path.
+    async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent, dispatch_all: bool) {
+        self.trigger_delayed_combo(key_action, event, event.pressed && dispatch_all)
+            .await;
+
+        if !dispatch_all {
+            let Some(key) = self.held_buffer.remove_if(|k| k.event.pos == event.pos) else {
+                return;
+            };
+            self.keymap.with_combos_mut(|combos| {
+                combos
+                    .iter_mut()
+                    .filter_map(|combo| combo.as_mut())
+                    .filter(|combo| !combo.is_triggered() && combo.config.contains(key_action))
+                    .for_each(Combo::reset);
+            });
+            self.process_key_action(&key.action, key.event, false, key.press_time)
+                .await;
+            return;
+        }
 
         // Dispatch every waiting key, earliest press first. Dispatching one key can
         // remove and re-push others, so look the next one up again instead of

--- a/rmk/src/keyboard.rs
+++ b/rmk/src/keyboard.rs
@@ -354,7 +354,28 @@ impl<'a> Keyboard<'a> {
         match key.state {
             KeyState::WaitingCombo => {
                 debug!("[Combo] Timeout, dispatch combo");
-                self.dispatch_combos(&key.action, key.event, false).await;
+                // A timeout is not an interrupting key press: only a delayed
+                // combo containing this key may fire.
+                let mut timeout_event = key.event;
+                timeout_event.pressed = false;
+                self.trigger_delayed_combo(&key.action, timeout_event).await;
+
+                if self
+                    .held_buffer
+                    .remove_if(|k| k.event.pos == key.event.pos && k.state == KeyState::WaitingCombo)
+                    .is_none()
+                {
+                    return;
+                }
+                self.keymap.with_combos_mut(|combos| {
+                    combos
+                        .iter_mut()
+                        .filter_map(|combo| combo.as_mut())
+                        .filter(|combo| !combo.is_triggered() && combo.config.contains(&key.action))
+                        .for_each(Combo::reset);
+                });
+                self.process_key_action(&key.action, key.event, false, key.press_time)
+                    .await;
             }
             _ => {
                 debug!("Buffered morse key timeout");
@@ -1004,8 +1025,7 @@ impl<'a> Keyboard<'a> {
     /// - `key_action`: The action of the key that triggered this function
     /// - `event`: The keyboard event. When pressing (interrupting), trigger any delayed combo.
     ///   When releasing, only trigger combos that contain the key_action.
-    /// - `interrupting_press`: Whether this is a new press rather than a buffered press timing out.
-    async fn trigger_delayed_combo(&mut self, key_action: &KeyAction, event: KeyboardEvent, interrupting_press: bool) {
+    async fn trigger_delayed_combo(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
         // First, find the delayed combo and trigger it
         let triggered_combo = self.keymap.with_combos_mut(|combos| {
             combos
@@ -1015,7 +1035,7 @@ impl<'a> Keyboard<'a> {
                     if c.is_all_pressed() && !c.is_triggered() {
                         // When a key is pressed (interrupting a combo wait), trigger any delayed combo.
                         // When releasing a key, only trigger combos that contain the key_action.
-                        if interrupting_press || c.config.contains(key_action) {
+                        if event.pressed || c.config.contains(key_action) {
                             // All keys are pressed but the combo is not triggered, trigger it
                             return Some((c.size(), c));
                         }
@@ -1076,7 +1096,7 @@ impl<'a> Keyboard<'a> {
 
         // First, when releasing a key, check whether there's untriggered combo, if so, triggerer it first
         if !event.pressed {
-            self.trigger_delayed_combo(key_action, event, false).await;
+            self.trigger_delayed_combo(key_action, event).await;
         }
 
         // If this is a re-press of a key belonging to an already-triggered combo
@@ -1202,32 +1222,14 @@ impl<'a> Keyboard<'a> {
             }
 
             // When no key is updated(the combo is interruptted), or a key is released,
-            self.dispatch_combos(key_action, event, true).await;
+            self.dispatch_combos(key_action, event).await;
             (Some(*key_action), false)
         }
     }
 
-    // Dispatch all waiting combo keys after an event interruption, or only the
-    // expired key when called by the deadline path.
-    async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent, dispatch_all: bool) {
-        self.trigger_delayed_combo(key_action, event, event.pressed && dispatch_all)
-            .await;
-
-        if !dispatch_all {
-            let Some(key) = self.held_buffer.remove_if(|k| k.event.pos == event.pos) else {
-                return;
-            };
-            self.keymap.with_combos_mut(|combos| {
-                combos
-                    .iter_mut()
-                    .filter_map(|combo| combo.as_mut())
-                    .filter(|combo| !combo.is_triggered() && combo.config.contains(key_action))
-                    .for_each(Combo::reset);
-            });
-            self.process_key_action(&key.action, key.event, false, key.press_time)
-                .await;
-            return;
-        }
+    // Dispatch combo keys buffered in the held buffer when the combo isn't being triggered.
+    async fn dispatch_combos(&mut self, key_action: &KeyAction, event: KeyboardEvent) {
+        self.trigger_delayed_combo(key_action, event).await;
 
         // Dispatch every waiting key, earliest press first. Dispatching one key can
         // remove and re-push others, so look the next one up again instead of

--- a/rmk/tests/scenarios/combo.toml
+++ b/rmk/tests/scenarios/combo.toml
@@ -59,6 +59,30 @@ steps = [
 ]
 expect = [["LAlt"], [], ["V"], []]
 
+# Timing out one combo attempt must not shorten a later, disjoint attempt's
+# timeout window. V starts first and expires while R still has 40ms left to
+# combine with T.
+[[test]]
+name = "disjoint_combo_timeout_preserves_later_window"
+behavior.combo = {
+  timeout = "100ms",
+  combos = [
+    { actions = ["V", "B"], output = "LShift", layer = 0 },
+    { actions = ["R", "T"], output = "LAlt", layer = 0 },
+  ]
+}
+steps = [
+  { press = [2, 3] },
+  { delay = 50 },
+  { press = [1, 5] },
+  { delay = 60 },
+  { press = [1, 6] },
+  { release = [1, 6] },
+  { release = [1, 5] },
+  { release = [2, 3] },
+]
+expect = [["V"], ["LAlt", "V"], ["V"], []]
+
 [[test]]
 name = "combo_with_mod_then_mod_timeout"
 steps = [


### PR DESCRIPTION
## Problem

The timeout for one pending combo calls the same path as a real key-event interruption. That path drains every `WaitingCombo` entry, including keys belonging to later, disjoint combo attempts whose own deadlines have not expired.

With a 100 ms timeout, pressing V, pressing R 50 ms later, and then pressing T after V expires but while R still has 40 ms left sends R to HID early. R+T therefore fails even though T arrived inside R's configured window. The new end-to-end scenario fails before this fix with `expected [LAlt, V], actual [R, V]`.

## Fix

- Keep the timeout-specific handling local to `fire_buffered_key_timeout`; existing combo dispatch function signatures stay unchanged.
- On timeout, trigger only a delayed combo containing the expired key; otherwise use the removed `WaitingCombo` entry directly, dispatch it, and reset only incomplete combos that contain it.
- Leave disjoint waiting keys and their independent deadlines intact.

The real key-event interruption path keeps its existing all-waiter dispatch behavior.

## Tests

- `cargo nextest run disjoint_combo_timeout_preserves_later_window --no-default-features --features=split,vial,storage,async_matrix,_ble`
- `cargo nextest run combo --no-default-features --features=split,vial,storage,async_matrix,_ble` (44 passed)
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` (523 passed)
- `bash scripts/format_all.sh`

## Risk

Low. The change is confined to combo timeout dispatch and is covered by the new cross-deadline scenario plus the existing combo suite. The PR changes 45 lines total (44 additions, 1 deletion).
