### PR TITLE
fix(encoder): resolve ratios without overflow

### DIFF
--- a/rmk-macro/src/codegen/input_device/encoder.rs
+++ b/rmk-macro/src/codegen/input_device/encoder.rs
@@ -5,6 +5,21 @@ use rmk_config::resolved::hardware::{ChipModel, EncoderConfig, EncoderResolution
 use super::Initializer;
 use crate::codegen::chip::gpio::convert_gpio_str_to_input_pin;
 
+fn resolve_encoder_resolution(config: &EncoderResolution) -> Result<u8, &'static str> {
+    match config {
+        EncoderResolution::Value(0) => Err("resolution must be at least 1"),
+        EncoderResolution::Value(resolution) => Ok(*resolution),
+        EncoderResolution::Derived { detent: 0, .. } => Err("resolution detent must be at least 1"),
+        EncoderResolution::Derived { detent, pulse } => {
+            let resolution = u16::from(*pulse) * 4 / u16::from(*detent);
+            if resolution == 0 {
+                return Err("derived resolution must be at least 1");
+            }
+            u8::try_from(resolution).map_err(|_| "derived resolution must not exceed 255")
+        }
+    }
+}
+
 /// Expand encoder device, this function returns the (device_initializer, processor_initializer)
 ///
 /// `id_offset` is the offset of the encoder id, it is used to distinguish the encoder id between central and peripheral
@@ -55,12 +70,12 @@ pub(crate) fn expand_encoder_device(
             }
             EncoderPhase::Resolution => {
                 // When phase is "resolution", ensure resolution and reverse are set
-                let resolution = match encoder.resolution.clone().expect(
-                    "`resolution` field needs to be set when the encoder's mode is 'resolution'",
-                ) {
-                    EncoderResolution::Value(r) => r,
-                    EncoderResolution::Derived { detent, pulse } => pulse * 4 / detent,
-                };
+                let resolution = encoder
+                    .resolution
+                    .as_ref()
+                    .ok_or("resolution must be set when phase is 'resolution'")
+                    .and_then(resolve_encoder_resolution)
+                    .unwrap_or_else(|message| panic!("encoder {encoder_id}: {message}"));
                 let reverse = encoder.reverse.unwrap_or(false);
 
                 quote! {
@@ -92,4 +107,47 @@ pub(crate) fn expand_encoder_device(
     }
 
     (device_initializer, vec![])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_encoder_resolution;
+    use rmk_config::resolved::hardware::EncoderResolution;
+
+    #[test]
+    fn derived_resolution_uses_wide_arithmetic() {
+        assert_eq!(
+            resolve_encoder_resolution(&EncoderResolution::Derived {
+                detent: 200,
+                pulse: 100,
+            }),
+            Ok(2)
+        );
+    }
+
+    #[test]
+    fn zero_and_out_of_range_resolutions_are_rejected() {
+        assert!(resolve_encoder_resolution(&EncoderResolution::Value(0)).is_err());
+        assert!(
+            resolve_encoder_resolution(&EncoderResolution::Derived {
+                detent: 0,
+                pulse: 1
+            })
+            .is_err()
+        );
+        assert!(
+            resolve_encoder_resolution(&EncoderResolution::Derived {
+                detent: 1,
+                pulse: 100
+            })
+            .is_err()
+        );
+        assert!(
+            resolve_encoder_resolution(&EncoderResolution::Derived {
+                detent: 200,
+                pulse: 1
+            })
+            .is_err()
+        );
+    }
 }

--- a/rmk/src/input_device/rotary_encoder.rs
+++ b/rmk/src/input_device/rotary_encoder.rs
@@ -89,11 +89,12 @@ impl Phase for E8H7Phase {
 pub struct ResolutionPhase {
     resolution: u8,
     lut: [i8; 16],
-    current_pulses: i8,
+    current_pulses: i16,
 }
 
 impl ResolutionPhase {
     pub fn new(resolution: u8, reverse: bool) -> Self {
+        assert!(resolution > 0, "encoder resolution must be at least 1");
         // Each entry corresponds to a state transition and provides +1, -1, or 0 pulse
         let mut lut = [0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0];
         if reverse {
@@ -107,13 +108,19 @@ impl ResolutionPhase {
     }
 
     pub fn new_with_detent_and_pulse(detent: u8, pulse: u8, reverse: bool) -> Self {
+        assert!(detent > 0, "encoder detent count must be at least 1");
+        let resolution = u16::from(pulse) * 4 / u16::from(detent);
+        assert!(
+            (1..=u16::from(u8::MAX)).contains(&resolution),
+            "derived encoder resolution must be between 1 and 255"
+        );
         // Each entry corresponds to a state transition and provides +1, -1, or 0 pulse
         let mut lut = [0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0];
         if reverse {
             lut = lut.map(|x| -x);
         }
         Self {
-            resolution: pulse * 4 / detent,
+            resolution: resolution as u8,
             lut,
             current_pulses: 0,
         }
@@ -125,13 +132,14 @@ impl Phase for ResolutionPhase {
         // Only proceed if there was a state change
         if (s & 0xC) != (s & 0x3) {
             // Add pulse value from the lookup table
-            self.current_pulses += self.lut[s as usize & 0xF];
+            self.current_pulses += i16::from(self.lut[s as usize & 0xF]);
+            let resolution = i16::from(self.resolution);
             // Check if we've reached the resolution threshold
-            if self.current_pulses >= self.resolution as i8 {
-                self.current_pulses %= self.resolution as i8;
+            if self.current_pulses >= resolution {
+                self.current_pulses %= resolution;
                 return Direction::CounterClockwise;
-            } else if self.current_pulses <= -(self.resolution as i8) {
-                self.current_pulses %= self.resolution as i8;
+            } else if self.current_pulses <= -resolution {
+                self.current_pulses %= resolution;
                 return Direction::Clockwise;
             }
         }
@@ -351,5 +359,10 @@ mod test {
             info!("Item: {:b}, {:?} {:?}", item, d, d2);
             assert_eq!(d, d2);
         }
+
+        assert_eq!(
+            ResolutionPhase::new_with_detent_and_pulse(200, 100, false).resolution,
+            2
+        );
     }
 }


### PR DESCRIPTION
## Problem

Derived rotary-encoder resolutions use the documented formula `(pulse * 4) / detent`, but the macro currently performs the multiplication in `u8`.

For `resolution = { detent = 200, pulse = 100 }`, the correct result is 2. A dev build panics while expanding `#[rmk_keyboard]` with `attempt to multiply with overflow`. A release build wraps `100 * 4` and expands `RotaryEncoder::with_resolution(..., 0u8, ...)`; the first qualifying encoder transition can then panic at `current_pulses %= resolution`.

Explicit zero values, a zero detent, and derived results outside `1..=255` were likewise accepted until expansion or runtime.

## Fix

- Compute the derived formula in `u16`, then convert the final result to `u8`.
- Reject explicit/derived zero, zero detents, and derived results above 255 with an encoder-specific expansion message.
- Keep the runtime pulse accumulator wide enough for every valid `u8` resolution, and apply the same checked formula in the Rust constructor.
- Cover wide arithmetic and invalid results with unit tests.

## Tests

- `cargo test` in `rmk-macro` (62 unit, 1 compile-fail, and 5 expansion tests passed)
- Real `examples/use_config/nrf52840_ble` dev check with `detent = 200, pulse = 100` passed after failing before the fix
- Release `cargo expand` emits `2u8` after emitting `0u8` before the fix
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` (522 passed)
- `bash scripts/format_all.sh`

## Risk

Low. Normal encoder resolutions are unchanged; valid large `u8` resolutions no longer wrap through the signed accumulator. Inputs that could only overflow, divide by zero, or produce an unusable runtime resolution now fail at construction or expansion. The PR changes 97 lines total (84 additions, 13 deletions).
