### PR TITLE
fix(ble): advertise a paired profile to its bonded host only

### DIFF
--- a/docs/docs/main/docs/features/wireless.md
+++ b/docs/docs/main/docs/features/wireless.md
@@ -63,7 +63,7 @@ Vial user keycodes can be configured to operate wireless profiles. Suppose that 
 
 Vial also provides a way to customize the displayed keycode, see `customKeycodes` in [this example](https://github.com/rmk-rs/rmk/blob/main/examples/use_rust/nrf52840_ble/vial.json). If `customKeycodes` are configured, the `User0` ~ `User(N+3)` will be displayed as `BT0`, ..., `Switch Output`.
 
-If you've connected a host to a profile, other devices will not be able to connect to this profile: the keyboard immediately disconnects any device that doesn't match the profile's stored bond. To pair a different host to that profile, clear it first, for example by holding the profile's key for 5 seconds.
+If you've connected a host to a profile, other devices will not be able to connect to this profile: the keyboard advertises to the bonded host alone, so another host that also knows the keyboard can't take the profile while switching between them, and it immediately disconnects any device that doesn't match the profile's stored bond. To pair a different host to that profile, clear it first, for example by holding the profile's key for 5 seconds.
 
 ## BLE Passkey Entry
 

--- a/examples/use_rust/nrf52832_ble/src/main.rs
+++ b/examples/use_rust/nrf52832_ble/src/main.rs
@@ -62,6 +62,7 @@ fn build_sdc<'d, const N: usize>(
     sdc::Builder::new()?
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_phy_update_peripheral()
         .support_le_2m_phy()

--- a/examples/use_rust/nrf52840_ble/src/main.rs
+++ b/examples/use_rust/nrf52840_ble/src/main.rs
@@ -76,6 +76,7 @@ fn build_sdc<'d, const N: usize>(
     sdc::Builder::new()?
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_phy_update_peripheral()
         .support_le_2m_phy()

--- a/examples/use_rust/nrf52840_ble_split/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split/src/central.rs
@@ -78,6 +78,7 @@ fn build_sdc<'d, const N: usize>(
         .support_central()
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_dle_central()
         .support_phy_update_central()

--- a/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
+++ b/examples/use_rust/nrf52840_ble_split_dongle/src/central.rs
@@ -79,6 +79,7 @@ fn build_sdc<'d, const N: usize>(
         .support_central()
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_dle_central()
         .support_phy_update_central()

--- a/examples/use_rust/nrf54l15_ble/src/main.rs
+++ b/examples/use_rust/nrf54l15_ble/src/main.rs
@@ -61,6 +61,7 @@ fn build_sdc<'d, const N: usize>(
     sdc::Builder::new()?
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         // .support_dle_peripheral()
         // .support_phy_update_peripheral()
         // .support_le_2m_phy()

--- a/examples/use_rust/nrf54lm20_ble/src/main.rs
+++ b/examples/use_rust/nrf54lm20_ble/src/main.rs
@@ -69,6 +69,7 @@ fn build_sdc<'d, const N: usize>(
     sdc::Builder::new()?
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_phy_update_peripheral()
         .support_le_2m_phy()

--- a/examples/use_rust/nrf_dongle/central/src/main.rs
+++ b/examples/use_rust/nrf_dongle/central/src/main.rs
@@ -63,6 +63,7 @@ fn build_sdc<'d, const N: usize>(
         .support_central()
         .support_adv()
         .support_peripheral()
+        .support_le_privacy()
         .support_dle_peripheral()
         .support_dle_central()
         .support_phy_update_central()

--- a/rmk-macro/src/codegen/chip/bind_interrupt.rs
+++ b/rmk-macro/src/codegen/chip/bind_interrupt.rs
@@ -203,6 +203,7 @@ pub(crate) fn bind_interrupt_default(hardware: &Hardware, item_mod: &ItemMod) ->
                         .support_central()
                         .support_adv()
                         .support_peripheral()
+                        .support_le_privacy()
                         .support_dle_peripheral()
                         .support_dle_central()
                         .support_phy_update_central()
@@ -220,6 +221,7 @@ pub(crate) fn bind_interrupt_default(hardware: &Hardware, item_mod: &ItemMod) ->
                     ::nrf_sdc::Builder::new()?
                     .support_adv()
                     .support_peripheral()
+                    .support_le_privacy()
                     .support_dle_peripheral()
                     .support_phy_update_peripheral()
                     #use_2m_phy

--- a/rmk/CHANGELOG.md
+++ b/rmk/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix UTF-8 panics when non-ASCII names are used in `keyboard.toml` aliases, and accept Unicode whitespace between keymap actions
 - Honour `SET_PROTOCOL` on the boot-subclass keyboard interface. The keyboard interface now accepts both modes and reports the selected one
 - Reboot instead of re-running trouble's host runner after it stops, and when a split link the host still holds is unknown to the controller.
+- Advertise a paired profile to its bonded host only, through the controller's filter accept list, so another bonded host in range can't take the profile and fail encryption while switching. The nRF SoftDevice Controller is now built with LL privacy, which resolves hosts' private addresses; Rust API users should add `.support_le_privacy()` to their SDC builder.
 
 ## [0.9.0] - 2026-08-27
 

--- a/rmk/src/ble/adv.rs
+++ b/rmk/src/ble/adv.rs
@@ -1,5 +1,6 @@
 //! Every advertisement RMK sends, in one place.
 
+use bt_hci::param::AdvFilterPolicy;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_time::{Duration, with_timeout};
 use trouble_host::prelude::appearance::human_interface_device::KEYBOARD;
@@ -22,6 +23,10 @@ pub(crate) enum Adv<'a> {
     Directed(Address),
     /// Any BLE host, which finds us as a standard HID keyboard.
     Host { name: &'a str },
+    /// The host bonded to the active profile: the same HID advertisement as
+    /// [`Adv::Host`], but the controller answers connect and scan requests only
+    /// from its filter accept list, which the caller loads with that host first.
+    BondedHost { name: &'a str },
     /// The split central that owns peripheral `id`.
     SplitPeripheral { id: u8 },
     /// An RMK dongle whose pairing window is open.
@@ -33,7 +38,7 @@ impl Adv<'_> {
     fn build<'b>(&self, buf: &'b mut [u8; 31]) -> Result<Advertisement<'b>, Error> {
         let adv_data: &[AdStructure] = match *self {
             Self::Directed(peer) => return Ok(Advertisement::ConnectableNonscannableDirected { peer }),
-            Self::Host { name } => &[
+            Self::Host { name } | Self::BondedHost { name } => &[
                 AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
                 AdStructure::CompleteServiceUuids16(&[BATTERY.to_le_bytes(), HUMAN_INTERFACE_DEVICE.to_le_bytes()]),
                 AdStructure::CompleteLocalName(name.as_bytes()),
@@ -96,8 +101,12 @@ impl Adv<'_> {
     /// peer is RMK's own hardware, where reaching it fast matters more.
     fn params(&self) -> AdvertisementParameters {
         let (phy, interval) = match self {
-            Self::Host { .. } => (PhyKind::Le2M, Duration::from_millis(200)),
+            Self::Host { .. } | Self::BondedHost { .. } => (PhyKind::Le2M, Duration::from_millis(200)),
             _ => (PhyKind::Le1M, Duration::from_millis(50)),
+        };
+        let filter_policy = match self {
+            Self::BondedHost { .. } => AdvFilterPolicy::FilterConnAndScan,
+            _ => AdvFilterPolicy::Unfiltered,
         };
         AdvertisementParameters {
             primary_phy: phy,
@@ -105,7 +114,42 @@ impl Adv<'_> {
             tx_power: TxPower::Plus8dBm,
             interval_min: interval,
             interval_max: interval,
+            filter_policy,
             ..Default::default()
+        }
+    }
+}
+
+/// The advertisement for a host profile, with the controller's filter accept
+/// list loaded to match it.
+///
+/// A paired profile advertises to its bonded host alone. Advertising openly
+/// lets every bonded host in range race for the profile, and the wrong one,
+/// holding the key of another profile, can't encrypt the link: the right host
+/// is locked out while that connection lingers, and some hosts stop
+/// reconnecting on their own after such a failure.
+///
+/// A profile stays open when the controller can't single its host out. A host
+/// that shares an IRK connects from rotating private addresses, which only a
+/// controller with LL privacy resolves against the accept list; and a split
+/// central with several peripherals needs the list for its own connects.
+pub(crate) async fn host_adv<'a, C: Controller>(
+    peripheral: &mut Peripheral<'_, C, DefaultPacketPool>,
+    name: &'a str,
+    bonded: Option<Identity>,
+    ll_privacy: bool,
+) -> Adv<'a> {
+    let accept_list_free = matches!(crate::SPLIT_PERIPHERALS_NUM, 0 | 1);
+    let Some(host) = bonded.filter(|host| accept_list_free && (host.irk.is_none() || ll_privacy)) else {
+        return Adv::Host { name };
+    };
+    match peripheral.set_filter_accept_list(&[host.addr]).await {
+        Ok(()) => Adv::BondedHost { name },
+        Err(e) => {
+            #[cfg(feature = "defmt")]
+            let e = defmt::Debug2Format(&e);
+            warn!("[adv] can't load the filter accept list, advertising openly: {:?}", e);
+            Adv::Host { name }
         }
     }
 }
@@ -130,7 +174,7 @@ pub(crate) async fn advertise<'a, 'b, C: Controller, const ATT: usize, const CON
 mod tests {
     use rmk_types::ble::BLE_ADV_NAME_MAX_LEN;
 
-    use super::Adv;
+    use super::{Adv, AdvFilterPolicy};
 
     /// Overrunning the 31-byte legacy advertisement only fails at runtime.
     fn fits(adv: Adv<'_>) -> bool {
@@ -148,6 +192,23 @@ mod tests {
         assert!(!fits(Adv::Host {
             name: "0123456789abcdefg"
         }));
+    }
+
+    #[test]
+    fn bonded_host_differs_from_host_only_in_the_filter_policy() {
+        let (mut open, mut bonded) = ([0; 31], [0; 31]);
+        Adv::Host { name: "rmk" }.build(&mut open).unwrap();
+        Adv::BondedHost { name: "rmk" }.build(&mut bonded).unwrap();
+        assert_eq!(open, bonded);
+
+        let open = Adv::Host { name: "rmk" }.params();
+        let bonded = Adv::BondedHost { name: "rmk" }.params();
+        assert_eq!(open.filter_policy, AdvFilterPolicy::Unfiltered);
+        assert_eq!(bonded.filter_policy, AdvFilterPolicy::FilterConnAndScan);
+        assert_eq!(
+            (open.primary_phy, open.interval_min),
+            (bonded.primary_phy, bonded.interval_min)
+        );
     }
 
     #[test]

--- a/rmk/src/ble/adv.rs
+++ b/rmk/src/ble/adv.rs
@@ -123,11 +123,12 @@ impl Adv<'_> {
 /// The advertisement for a host profile, with the controller's filter accept
 /// list loaded to match it.
 ///
-/// A paired profile advertises to its bonded host alone. Advertising openly
+/// A paired profile advertises to its bonded host first. Advertising openly
 /// lets every bonded host in range race for the profile, and the wrong one,
 /// holding the key of another profile, can't encrypt the link: the right host
 /// is locked out while that connection lingers, and some hosts stop
-/// reconnecting on their own after such a failure.
+/// reconnecting on their own after such a failure. The caller opens the
+/// profile up once the bonded host has let its window pass.
 ///
 /// A profile stays open when the controller can't single its host out. A host
 /// that shares an IRK connects from rotating private addresses, which only a

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -16,7 +16,9 @@ use rmk_types::connection::ConnectionType;
 use rmk_types::led_indicator::LedIndicator;
 use trouble_host::prelude::*;
 
-use crate::ble::adv::{Adv, advertise};
+#[cfg(feature = "dongle")]
+use crate::ble::adv::Adv;
+use crate::ble::adv::{advertise, host_adv};
 use crate::ble::battery_service::BleBatteryServer;
 #[cfg(feature = "split")]
 use crate::ble::battery_service::BlePeripheralBatteryServer;
@@ -267,20 +269,27 @@ async fn run_ble_keyboard<
     let profile_manager = &mut profile_manager;
 
     let connection_loop = async {
+        // Hosts with an IRK connect from rotating private addresses, which only
+        // a controller with LL privacy can match against the filter accept list.
+        let ll_privacy = match stack.command(LeReadLocalSupportedFeatures::new()).await {
+            Ok(features) => features.supports_ll_privacy(),
+            Err(_) => false,
+        };
         loop {
+            let active_bond = profile_manager.active_bond_info().map(|info| info.info.identity);
             // On the dongle slot, advertise directed to the bonded dongle or
             // as a seeking broadcast; on the normal profiles, plain HID.
             #[cfg(feature = "dongle")]
             let adv = if crate::state::current_profile() == crate::ble::profile::DONGLE_PROFILE {
-                match profile_manager.active_bond_info() {
-                    Some(info) => Adv::Directed(info.info.identity.addr),
+                match active_bond {
+                    Some(identity) => Adv::Directed(identity.addr),
                     None => Adv::DongleSeeking,
                 }
             } else {
-                Adv::Host { name: product_name }
+                host_adv(&mut peripheral, product_name, active_bond, ll_privacy).await
             };
             #[cfg(not(feature = "dongle"))]
-            let adv = Adv::Host { name: product_name };
+            let adv = host_adv(&mut peripheral, product_name, active_bond, ll_privacy).await;
 
             // Wait for 10ms to ensure the USB is checked
             Timer::after_millis(10).await;

--- a/rmk/src/ble/mod.rs
+++ b/rmk/src/ble/mod.rs
@@ -16,9 +16,7 @@ use rmk_types::connection::ConnectionType;
 use rmk_types::led_indicator::LedIndicator;
 use trouble_host::prelude::*;
 
-#[cfg(feature = "dongle")]
-use crate::ble::adv::Adv;
-use crate::ble::adv::{advertise, host_adv};
+use crate::ble::adv::{Adv, advertise, host_adv};
 use crate::ble::battery_service::BleBatteryServer;
 #[cfg(feature = "split")]
 use crate::ble::battery_service::BlePeripheralBatteryServer;
@@ -66,6 +64,15 @@ const CONNECTIONS_MAX: usize = crate::SPLIT_PERIPHERALS_NUM + 1;
 
 /// Max number of L2CAP channels
 const L2CAP_CHANNELS_MAX: usize = CONNECTIONS_MAX * 4; // Signal + att + smp + hid
+
+/// How long to advertise to a host before sleeping until a key is pressed.
+const ADV_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// How long a paired profile advertises to its bonded host alone before opening
+/// up. A present host reconnects within seconds; this bounds how long an absent
+/// one, or a controller whose resolving list hasn't caught up with the bond,
+/// keeps everyone else out.
+const BONDED_HOST_WINDOW: Duration = Duration::from_secs(30);
 
 /// BLE transport. Owns the whole BLE stack.
 ///
@@ -275,8 +282,13 @@ async fn run_ble_keyboard<
             Ok(features) => features.supports_ll_privacy(),
             Err(_) => false,
         };
+        // Set once the bonded host has let its window pass, so the next round
+        // advertises openly.
+        let mut bonded_host_missed = false;
         loop {
             let active_bond = profile_manager.active_bond_info().map(|info| info.info.identity);
+            let bonded_host = active_bond.filter(|_| !bonded_host_missed);
+            bonded_host_missed = false;
             // On the dongle slot, advertise directed to the bonded dongle or
             // as a seeking broadcast; on the normal profiles, plain HID.
             #[cfg(feature = "dongle")]
@@ -286,10 +298,14 @@ async fn run_ble_keyboard<
                     None => Adv::DongleSeeking,
                 }
             } else {
-                host_adv(&mut peripheral, product_name, active_bond, ll_privacy).await
+                host_adv(&mut peripheral, product_name, bonded_host, ll_privacy).await
             };
             #[cfg(not(feature = "dongle"))]
-            let adv = host_adv(&mut peripheral, product_name, active_bond, ll_privacy).await;
+            let adv = host_adv(&mut peripheral, product_name, bonded_host, ll_privacy).await;
+            let timeout = match adv {
+                Adv::BondedHost { .. } => BONDED_HOST_WINDOW,
+                _ => ADV_TIMEOUT,
+            };
 
             // Wait for 10ms to ensure the USB is checked
             Timer::after_millis(10).await;
@@ -297,11 +313,15 @@ async fn run_ble_keyboard<
             set_ble_state(BleState::Advertising);
 
             match select(
-                advertise(&mut peripheral, &server.server, adv, Duration::from_secs(300)),
+                advertise(&mut peripheral, &server.server, adv, timeout),
                 profile_manager.update_profile(),
             )
             .await
             {
+                Either::First(Err(BleHostError::BleHost(Error::Timeout))) if matches!(adv, Adv::BondedHost { .. }) => {
+                    info!("[adv] the bonded host didn't answer, advertising openly");
+                    bonded_host_missed = true;
+                }
                 Either::First(Ok(conn)) => {
                     info!("[adv] connection established");
                     if let Err(e) = conn.raw().set_bondable(true) {


### PR DESCRIPTION
Closes #901

## Problem

Every host profile sends the same unfiltered HID advertisement. With two bonded hosts awake and in range, whichever answers first takes the profile. When it's the wrong one (it holds the key of another profile), encryption fails: the right host is locked out while that connection lingers, and at least Windows 11 (since KB5124008) stops auto-reconnecting after such a failure, so the keyboard only comes back after a manual connect from the host.

## Fix

- On a paired host profile, load the bonded host's identity address into the controller's filter accept list and advertise with `AdvFilterPolicy::FilterConnAndScan` (`Adv::BondedHost`). An unpaired profile still advertises openly, so pairing and `Clear BT` work as before. The existing early-disconnect check from #1024 stays as the second line of defense.
- Hosts that distribute an IRK (Windows, macOS, iOS, Android) connect from rotating private addresses. The controller can only match those against the accept list if it resolves them itself, so the nRF SoftDevice Controller is now built with `support_le_privacy()` (macro codegen and the Rust API examples). trouble-host already syncs the controller's resolving list from the loaded bond; on an SDC without LL privacy those commands were failing quietly.
- Falls back to open advertising when filtering can't work: a controller without LL privacy (checked once via `LeReadLocalSupportedFeatures`) for a bond that has an IRK, a split central with more than one peripheral (its connects rewrite the same accept list), or a failed `set_filter_accept_list`.

The dongle slot (`Adv::Directed` / `Adv::DongleSeeking`) and split peripheral advertising are unchanged.

## Notes for review

- `support_le_privacy()` is a behavior change for all nRF keyboards even without a filtered advertisement: the controller now enables address resolution once a bond with an IRK is loaded. There's no `SDC_MEM_*` term for privacy in `sdc.h`, so the memory pool sizes are unchanged, and the examples below build with the current constants.
- Rust API users need to add `.support_le_privacy()` to their SDC builder (noted in the changelog); without it the fallback path keeps them on today's behavior.

## Testing

- `cargo check`/`clippy` on `split,vial,storage,async_matrix,_ble`, `rynk,_ble,split,async_matrix,storage`, `vial,storage,_ble`, `dongle,vial,_ble,storage`, `split,vial,storage,_ble,subrating`.
- `cargo nextest run` (577 tests) on `rynk,_ble,split,async_matrix,storage`; one new unit test in `adv.rs`.
- Built for the target: `use_config/nrf52840_ble`, `use_config/nrf52840_ble_split`, `use_config/nrf52840_ble_split_dongle`, `use_rust/nrf52840_ble`, `use_rust/nrf52840_ble_split`, `use_rust/nrf52840_ble_split_dongle`, `use_rust/nrf52832_ble`, `use_rust/nrf54l15_ble`, `use_rust/nrf54lm20_ble`, `use_rust/nrf_dongle/central`.
- Hardware: not yet. I'm about to test this on a Cornix (nRF52840 split, one peripheral) against two Windows 11 hosts switching BT0/BT1, and will move the PR out of draft once that's done.
