### PR TITLE
fix(hid): widen mouse report axes to 16 bits

### DIFF
--- a/docs/docs/main/docs/configuration/input_device/joystick.md
+++ b/docs/docs/main/docs/configuration/input_device/joystick.md
@@ -64,7 +64,7 @@ The transform might be not very intuitive, please read the document below for mo
 
    If `transform[new_axis][old_axis]` is 0, that old axis value is ignored.
 
-   Since the value range read by the ADC device is usually much larger than the mouse report range of -128~127 (values outside it are clamped), `transform` is designed as a divisor.
+   Since the value range read by the ADC device is usually much larger than a comfortable per-report cursor step, `transform` is designed as a divisor.
 
 4. Each axis value is adjusted to the largest integer multiple of `resolution` that is less than its original value to reduce noise from ADC device readings.
 

--- a/rmk-macro/src/codegen/simulator.rs
+++ b/rmk-macro/src/codegen/simulator.rs
@@ -450,15 +450,15 @@ fn expectation(value: &Value) -> Result<TokenStream2, String> {
             #[serde(deny_unknown_fields, default)]
             struct Mouse {
                 buttons: u8,
-                x: i8,
-                y: i8,
-                wheel: i8,
-                pan: i8,
+                x: i16,
+                y: i16,
+                wheel: i16,
+                pan: i16,
             }
             let m: Mouse = arg(v, op, "{ buttons, x, y, wheel, pan }")?;
             let (buttons, x, y, wheel, pan) = (m.buttons, m.x, m.y, m.wheel, m.pan);
             quote! {
-                .expect_report(::rmk::hid::Report::MouseReport(::usbd_hid::descriptor::MouseReport {
+                .expect_report(::rmk::hid::Report::MouseReport(::rmk::hid::MouseReport {
                     buttons: #buttons,
                     x: #x,
                     y: #y,

--- a/rmk/src/ble/ble_server.rs
+++ b/rmk/src/ble/ble_server.rs
@@ -11,7 +11,7 @@ use crate::dongle::event::{DONGLE_EVENT_CHAR_UUID, DONGLE_EVENT_MAX, DONGLE_EVEN
 use crate::hid::RynkHidReport;
 #[cfg(feature = "vial")]
 use crate::hid::ViaReport;
-use crate::hid::{BleCompositeReport, CompositeReportType, HidError, HidWriterTrait, Report};
+use crate::hid::{BleCompositeReport, CompositeReportType, HidError, HidWriterTrait, MOUSE_REPORT_SIZE, Report};
 
 // Used for saving the client attribute (CCCD) table. Tracks the trouble-host
 // per-connection client-specific attribute buffer size.
@@ -122,8 +122,8 @@ pub(crate) struct VialGattService {
 pub(crate) struct HidService {
     #[characteristic(uuid = "2a4a", read, value = [0x01, 0x01, 0x00, 0x03])]
     pub(crate) hid_info: [u8; 4],
-    #[characteristic(uuid = "2a4b", read, value = BleCompositeReport::desc().try_into().expect("Failed to convert BleCompositeReport to [u8; 178]"))]
-    pub(crate) report_map: [u8; 178],
+    #[characteristic(uuid = "2a4b", read, value = BleCompositeReport::desc().try_into().expect("Failed to convert BleCompositeReport to [u8; 177]"))]
+    pub(crate) report_map: [u8; 177],
     #[characteristic(uuid = "2a4c", write_without_response)]
     pub(crate) hid_control_point: u8,
     #[characteristic(uuid = "2a4e", read, write_without_response, value = 1)]
@@ -136,7 +136,7 @@ pub(crate) struct HidService {
     pub(crate) output_keyboard: [u8; 1],
     #[descriptor(uuid = "2908", read, value = [CompositeReportType::Mouse as u8, 1u8])]
     #[characteristic(uuid = "2a4d", read, notify)]
-    pub(crate) mouse_report: [u8; 5],
+    pub(crate) mouse_report: [u8; MOUSE_REPORT_SIZE],
     #[descriptor(uuid = "2908", read, value = [CompositeReportType::Media as u8, 1u8])]
     #[characteristic(uuid = "2a4d", read, notify)]
     pub(crate) media_report: [u8; 2],
@@ -147,7 +147,7 @@ pub(crate) struct HidService {
 
 pub(crate) struct BleHidServer<'stack, 'server, 'conn, P: PacketPool> {
     input_keyboard: Characteristic<[u8; 8]>,
-    mouse_report: Characteristic<[u8; 5]>,
+    mouse_report: Characteristic<[u8; MOUSE_REPORT_SIZE]>,
     media_report: Characteristic<[u8; 2]>,
     system_report: Characteristic<[u8; 1]>,
     conn: &'conn GattConnection<'stack, 'server, P>,

--- a/rmk/src/dongle/mod.rs
+++ b/rmk/src/dongle/mod.rs
@@ -33,7 +33,7 @@ pub use router::DongleRouter;
 #[cfg(feature = "vial")]
 use router::VialReport;
 use trouble_host::prelude::*;
-use usbd_hid::descriptor::{MediaKeyboardReport, MouseReport, SystemControlReport};
+use usbd_hid::descriptor::{MediaKeyboardReport, SystemControlReport};
 #[cfg(feature = "vial")]
 use vial_router as router;
 
@@ -47,7 +47,7 @@ use crate::dongle::event::{DONGLE_EVENT_CHAR_UUID, DONGLE_EVENT_SERVICE_UUID, Do
 use crate::event::{
     DongleState, DongleStateEvent, EventSubscriber, LedIndicatorEvent, SubscribableEvent, publish_event,
 };
-use crate::hid::{CompositeReportType, KeyboardReport, Report};
+use crate::hid::{CompositeReportType, KeyboardReport, MOUSE_REPORT_SIZE, MouseReport, Report};
 use crate::{DONGLE_PAIRING_WINDOW_SECS, RawMutex};
 
 /// The dongle relays exactly one keyboard.
@@ -649,13 +649,13 @@ impl KeyboardCharacteristics {
                 leds: 0,
                 keycodes: data[2..8].try_into().unwrap(),
             }))
-        } else if handle == self.mouse.handle && data.len() >= 5 {
+        } else if handle == self.mouse.handle && data.len() >= MOUSE_REPORT_SIZE {
             Some(Report::MouseReport(MouseReport {
                 buttons: data[0],
-                x: data[1] as i8,
-                y: data[2] as i8,
-                wheel: data[3] as i8,
-                pan: data[4] as i8,
+                x: i16::from_le_bytes([data[1], data[2]]),
+                y: i16::from_le_bytes([data[3], data[4]]),
+                wheel: i16::from_le_bytes([data[5], data[6]]),
+                pan: i16::from_le_bytes([data[7], data[8]]),
             }))
         } else if handle == self.media.handle && data.len() >= 2 {
             Some(Report::MediaKeyboardReport(MediaKeyboardReport {

--- a/rmk/src/hid.rs
+++ b/rmk/src/hid.rs
@@ -10,7 +10,7 @@ use rmk_types::led_indicator::LedIndicator;
 use rmk_types::protocol::rynk::RYNK_HID_REPORT_SIZE;
 use serde::Serialize;
 use usbd_hid::descriptor::generator_prelude::*;
-use usbd_hid::descriptor::{AsInputReport, MediaKeyboardReport, MouseReport, SystemControlReport};
+use usbd_hid::descriptor::{AsInputReport, BufferOverflow, MediaKeyboardReport, SystemControlReport};
 
 use crate::event::{LedIndicatorEvent, publish_event};
 use crate::keyboard::LOCK_LED_STATES;
@@ -173,6 +173,39 @@ mod steno_tests {
     }
 }
 
+/// Wire size of [`MouseReport`]: sizes the BLE report characteristic and the
+/// USB composite write buffer.
+pub(crate) const MOUSE_REPORT_SIZE: usize = 9;
+
+/// Mouse HID report.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MouseReport {
+    pub buttons: u8, // MouseButtons
+    pub x: i16,
+    pub y: i16,
+    /// Scroll down (negative) or up (positive) this many units
+    pub wheel: i16,
+    /// Scroll left (negative) or right (positive) this many units
+    pub pan: i16,
+}
+
+/// Hand-written because `gen_hid_descriptor` emits a `repr(packed)` struct,
+/// which with 16-bit axes makes every `&report.x` a compile error for callers.
+impl AsInputReport for MouseReport {
+    fn serialize(&self, buffer: &mut [u8]) -> Result<usize, BufferOverflow> {
+        if buffer.len() < MOUSE_REPORT_SIZE {
+            return Err(BufferOverflow);
+        }
+        buffer[0] = self.buttons;
+        buffer[1..3].copy_from_slice(&self.x.to_le_bytes());
+        buffer[3..5].copy_from_slice(&self.y.to_le_bytes());
+        buffer[5..7].copy_from_slice(&self.wheel.to_le_bytes());
+        buffer[7..9].copy_from_slice(&self.pan.to_le_bytes());
+        Ok(MOUSE_REPORT_SIZE)
+    }
+}
+
 /// A composite hid report which contains mouse, consumer, system reports.
 /// Report id is used to distinguish from them.
 #[gen_hid_descriptor(
@@ -219,12 +252,54 @@ mod steno_tests {
 #[derive(Default, Serialize)]
 pub struct CompositeReport {
     pub(crate) buttons: u8, // MouseButtons
-    pub(crate) x: i8,
-    pub(crate) y: i8,
-    pub(crate) wheel: i8, // Scroll down (negative) or up (positive) this many units
-    pub(crate) pan: i8,   // Scroll left (negative) or right (positive) this many units
+    pub(crate) x: i16,
+    pub(crate) y: i16,
+    pub(crate) wheel: i16, // Scroll down (negative) or up (positive) this many units
+    pub(crate) pan: i16,   // Scroll left (negative) or right (positive) this many units
     pub(crate) media_usage_id: u16,
     pub(crate) system_usage_id: u8,
+}
+
+#[cfg(test)]
+mod mouse_report_tests {
+    use usbd_hid::descriptor::{AsInputReport, SerializedDescriptor};
+
+    use super::{CompositeReport, MOUSE_REPORT_SIZE, MouseReport};
+
+    /// The report map tells the host how to parse the axes and `serialize`
+    /// writes them; only this test holds the two to the same widths.
+    #[test]
+    fn mouse_report_matches_composite_descriptor() {
+        let desc = CompositeReport::desc();
+        fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+            haystack.windows(needle.len()).position(|w| w == needle)
+        }
+        let start = find(desc, &[0x85, 0x02]).expect("missing mouse ReportID 2");
+        let end = find(desc, &[0x85, 0x03]).expect("missing consumer ReportID 3");
+        let mouse = &desc[start..end];
+        assert!(
+            find(mouse, &[0x17, 0x01, 0x80, 0xff, 0xff]).is_some(),
+            "missing LogicalMinimum -32767"
+        );
+        assert!(
+            find(mouse, &[0x26, 0xff, 0x7f]).is_some(),
+            "missing LogicalMaximum 32767"
+        );
+        assert!(find(mouse, &[0x75, 0x10]).is_some(), "missing ReportSize 16");
+        assert!(find(mouse, &[0x25, 0x7f]).is_none(), "an axis is still 8-bit");
+
+        // A delta past the old 8-bit ceiling survives the wire encoding.
+        let report = MouseReport {
+            buttons: 0x03,
+            x: 300,
+            y: -300,
+            wheel: 1,
+            pan: -1,
+        };
+        let mut buf = [0u8; MOUSE_REPORT_SIZE];
+        assert_eq!(report.serialize(&mut buf).unwrap(), MOUSE_REPORT_SIZE);
+        assert_eq!(buf, [0x03, 0x2c, 0x01, 0xd4, 0xfe, 0x01, 0x00, 0xff, 0xff]);
+    }
 }
 
 /// The BLE report map: everything in one HID service, distinguished by report id.
@@ -301,10 +376,10 @@ pub struct BleCompositeReport {
     pub(crate) leds: u8,
     pub(crate) keycodes: [u8; 6],
     pub(crate) buttons: u8,
-    pub(crate) x: i8,
-    pub(crate) y: i8,
-    pub(crate) wheel: i8,
-    pub(crate) pan: i8,
+    pub(crate) x: i16,
+    pub(crate) y: i16,
+    pub(crate) wheel: i16,
+    pub(crate) pan: i16,
     pub(crate) media_usage_id: u16,
     pub(crate) system_usage_id: u8,
 }
@@ -323,7 +398,7 @@ mod ble_report_map_tests {
         fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
             haystack.windows(needle.len()).position(|w| w == needle)
         }
-        assert_eq!(desc.len(), 178, "update HidService's report_map size on change");
+        assert_eq!(desc.len(), 177, "update HidService's report_map size on change");
         let keyboard = find(desc, &[0x09, 0x06]).expect("missing Usage Keyboard");
         for report_id in 1u8..=4 {
             let id = find(desc, &[0x85, report_id]).unwrap_or_else(|| panic!("missing ReportID {report_id}"));

--- a/rmk/src/input_device/joystick.rs
+++ b/rmk/src/input_device/joystick.rs
@@ -1,9 +1,8 @@
 use rmk_macro::processor;
-use usbd_hid::descriptor::MouseReport;
 
 use crate::channel::send_hid_report;
 use crate::event::PointingEvent;
-use crate::hid::Report;
+use crate::hid::{MouseReport, Report};
 use crate::input_device::pointing::ALL_POINTING_DEVICES;
 use crate::keymap::KeyMap;
 
@@ -71,8 +70,8 @@ impl<'a, const N: usize> JoystickProcessor<'a, N> {
         let buttons = self.keymap.mouse_buttons();
         let mouse_report = MouseReport {
             buttons,
-            x: (report[0].clamp(i8::MIN as i16, i8::MAX as i16)) as i8,
-            y: (report[1].clamp(i8::MIN as i16, i8::MAX as i16)) as i8,
+            x: report[0],
+            y: report[1],
             wheel: 0,
             pan: 0,
         };

--- a/rmk/src/input_device/pointing.rs
+++ b/rmk/src/input_device/pointing.rs
@@ -6,11 +6,10 @@ use embedded_hal_async::digital::Wait;
 use futures::future::pending;
 use rmk_macro::{input_device, processor};
 use rmk_types::keycode::HidKeyCode;
-use usbd_hid::descriptor::MouseReport;
 
 use crate::channel::send_hid_report;
 use crate::event::{Axis, AxisEvent, AxisValType, PointingEvent, PointingProcessorEvent, PointingSetCpiEvent};
-use crate::hid::{KeyboardReport, Report};
+use crate::hid::{KeyboardReport, MouseReport, Report};
 use crate::keymap::KeyMap;
 
 pub const ALL_POINTING_DEVICES: u8 = 255;
@@ -573,8 +572,8 @@ impl<'a> PointingProcessor<'a> {
                         let out_y = if cursor_config.invert_y { -out_y } else { out_y };
                         MouseReport {
                             buttons,
-                            x: out_x.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
-                            y: out_y.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
+                            x: out_x,
+                            y: out_y,
                             wheel: 0,
                             pan: 0,
                         }
@@ -598,8 +597,8 @@ impl<'a> PointingProcessor<'a> {
                             buttons,
                             x: 0,
                             y: 0,
-                            wheel: wheel.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
-                            pan: pan.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
+                            wheel,
+                            pan,
                         }
                     }
                     PointingMode::Sniper(sniper_config) => {
@@ -616,8 +615,8 @@ impl<'a> PointingProcessor<'a> {
                         let out_y = if sniper_config.invert_y { -sy } else { sy };
                         MouseReport {
                             buttons,
-                            x: out_x.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
-                            y: out_y.clamp(i8::MIN as i16, i8::MAX as i16) as i8,
+                            x: out_x,
+                            y: out_y,
                             wheel: 0,
                             pan: 0,
                         }

--- a/rmk/src/keyboard/mouse.rs
+++ b/rmk/src/keyboard/mouse.rs
@@ -8,9 +8,9 @@
 
 use embassy_time::{Duration, Instant};
 use rmk_types::keycode::HidKeyCode;
-use usbd_hid::descriptor::MouseReport;
 
 use crate::config::MouseKeyConfig;
+use crate::hid::MouseReport;
 
 /// Result of processing a mouse key event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -124,10 +124,10 @@ impl DirectionState {
     }
 
     /// Compute axis values by applying `unit` magnitude to the active directions.
-    fn axis_values(&self, unit: i8) -> (i8, i8) {
+    fn axis_values(&self, unit: i16) -> (i16, i16) {
         (
-            self.x.signum().saturating_mul(unit),
-            self.y.signum().saturating_mul(unit),
+            (self.x.signum() as i16).saturating_mul(unit),
+            (self.y.signum() as i16).saturating_mul(unit),
         )
     }
 
@@ -306,7 +306,7 @@ impl MouseState {
     /// Two-step speed calculation:
     /// Step 1: acceleration curve based on repeat count
     /// Step 2: accel multiplier (Accel0=0.25x, Accel1=0.5x, Accel2=2.0x, highest wins)
-    fn calculate_unit(accel: u8, repeat: u8, delta: u8, max_speed: u8, ticks_to_max: u8, max: u8) -> i8 {
+    fn calculate_unit(accel: u8, repeat: u8, delta: u8, max_speed: u8, ticks_to_max: u8, max: u8) -> i16 {
         // Step 1: Base value from acceleration curve
         let max_unit = (delta as u16).saturating_mul(max_speed as u16);
         let base: u16 = if repeat == 0 {
@@ -339,7 +339,7 @@ impl MouseState {
             base
         };
 
-        // Step 3: Clamp to [1, max] and i8 range
+        // Step 3: Clamp to [1, max]
         let clamped = if max == 0 {
             1u16
         } else if multiplied > max as u16 {
@@ -349,11 +349,11 @@ impl MouseState {
         } else {
             multiplied
         };
-        clamped.min(i8::MAX as u16) as i8
+        clamped as i16
     }
 
     /// Calculate mouse movement distance based on current repeat count and acceleration settings
-    fn calculate_move_unit(&self, config: &MouseKeyConfig) -> i8 {
+    fn calculate_move_unit(&self, config: &MouseKeyConfig) -> i16 {
         Self::calculate_unit(
             self.accel,
             self.movement.repeat,
@@ -365,7 +365,7 @@ impl MouseState {
     }
 
     /// Calculate mouse wheel movement distance based on current repeat count and acceleration settings
-    fn calculate_wheel_unit(&self, config: &MouseKeyConfig) -> i8 {
+    fn calculate_wheel_unit(&self, config: &MouseKeyConfig) -> i16 {
         Self::calculate_unit(
             self.accel,
             self.wheel.repeat,
@@ -377,23 +377,24 @@ impl MouseState {
     }
 
     /// Apply diagonal movement compensation (approximation of 1/sqrt(2))
-    fn apply_diagonal_compensation(mut x: i8, mut y: i8) -> (i8, i8) {
+    fn apply_diagonal_compensation(mut x: i16, mut y: i16) -> (i16, i16) {
         if x != 0 && y != 0 {
-            let x16 = x as i16;
-            let y16 = y as i16;
-            let x_bias: i16 = if x16 >= 0 { 128 } else { -128 };
-            let y_bias: i16 = if y16 >= 0 { 128 } else { -128 };
-            let x_compensated = (x16 * 181 + x_bias) / 256;
-            let y_compensated = (y16 * 181 + y_bias) / 256;
-            x = if x_compensated == 0 && x != 0 {
+            // Widen so the 181/256 multiply can't overflow.
+            let x32 = x as i32;
+            let y32 = y as i32;
+            let x_bias: i32 = if x32 >= 0 { 128 } else { -128 };
+            let y_bias: i32 = if y32 >= 0 { 128 } else { -128 };
+            let x_compensated = (x32 * 181 + x_bias) / 256;
+            let y_compensated = (y32 * 181 + y_bias) / 256;
+            x = if x_compensated == 0 {
                 if x > 0 { 1 } else { -1 }
             } else {
-                x_compensated as i8
+                x_compensated as i16
             };
-            y = if y_compensated == 0 && y != 0 {
+            y = if y_compensated == 0 {
                 if y > 0 { 1 } else { -1 }
             } else {
-                y_compensated as i8
+                y_compensated as i16
             };
         }
         (x, y)
@@ -762,10 +763,11 @@ mod test {
     }
 
     #[test]
-    fn calculate_unit_i8_max_clamp() {
-        // Very large values should clamp to i8::MAX (127)
+    fn calculate_unit_clamps_to_max() {
+        // `max` is the only cap; the report axes are 16-bit, so a `move_max`
+        // above 127 survives instead of being truncated.
         let result = MouseState::calculate_unit(4, 50, 100, 10, 50, 255);
-        assert_eq!(result, 127);
+        assert_eq!(result, 255);
     }
 
     // -- H. Return value semantics --------------------------------------------

--- a/rmk/src/usb/mod.rs
+++ b/rmk/src/usb/mod.rs
@@ -18,7 +18,8 @@ use crate::core_traits::Runnable;
 #[cfg(feature = "steno")]
 use crate::hid::StenoReport;
 use crate::hid::{
-    CompositeReport, CompositeReportType, HidError, HidWriterTrait, KeyboardReport, Report, run_led_reader,
+    CompositeReport, CompositeReportType, HidError, HidWriterTrait, KeyboardReport, MOUSE_REPORT_SIZE, Report,
+    run_led_reader,
 };
 use crate::light::UsbLedReader;
 use crate::state::{current_usb_state, set_usb_state};
@@ -61,7 +62,7 @@ impl HostSession for () {
 /// concurrently without moving the whole transport into one task.
 pub(crate) struct UsbKeyboardWriter<'a, 'd, D: Driver<'d>> {
     pub(crate) keyboard_writer: &'a mut HidWriter<'d, D, 8>,
-    pub(crate) other_writer: &'a mut HidWriter<'d, D, 9>,
+    pub(crate) other_writer: &'a mut HidWriter<'d, D, COMPOSITE_WRITE_SIZE>,
     #[cfg(feature = "steno")]
     pub(crate) steno_writer: &'a mut HidWriter<'d, D, 9>,
 }
@@ -101,7 +102,7 @@ impl<'d, D: Driver<'d>> UsbKeyboardWriter<'_, 'd, D> {
         kind: CompositeReportType,
         report: &R,
     ) -> Result<usize, HidError> {
-        let mut buf = [0u8; 9];
+        let mut buf = [0u8; COMPOSITE_WRITE_SIZE];
         buf[0] = kind as u8;
         let n = report
             .serialize(&mut buf[1..])
@@ -159,6 +160,9 @@ impl<'d, D: Driver<'d>> HidWriterTrait for UsbKeyboardWriter<'_, 'd, D> {
         }
     }
 }
+
+/// Report id byte plus the largest composite payload, which is the mouse report.
+const COMPOSITE_WRITE_SIZE: usize = 1 + MOUSE_REPORT_SIZE;
 
 /// Extra interfaces (usb_log, steno, dfu, rynk) overflow the 128-byte buffer.
 const DEFAULT_CONFIG_DESC_SIZE: usize = if cfg!(any(
@@ -250,7 +254,7 @@ pub struct UsbTransport<'a, D: Driver<'static>, S = ()> {
     device: UsbDevice<'static, D>,
     keyboard_reader: HidReader<'static, D, 1>,
     keyboard_writer: HidWriter<'static, D, 8>,
-    other_writer: HidWriter<'static, D, 9>,
+    other_writer: HidWriter<'static, D, COMPOSITE_WRITE_SIZE>,
     #[cfg(feature = "steno")]
     steno_writer: HidWriter<'static, D, 9>,
     /// Taken by `run`: the logger future consumes the CDC class.
@@ -289,7 +293,7 @@ impl<'a, D: Driver<'static>> UsbTransport<'a, D> {
 pub struct UsbTransportBuilder<D: Driver<'static>> {
     builder: Builder<'static, D>,
     keyboard_rw: HidReaderWriter<'static, D, 1, 8>,
-    other_writer: HidWriter<'static, D, 9>,
+    other_writer: HidWriter<'static, D, COMPOSITE_WRITE_SIZE>,
     #[cfg(feature = "steno")]
     steno_writer: HidWriter<'static, D, 9>,
     #[cfg(feature = "usb_log")]
@@ -325,7 +329,7 @@ impl<D: Driver<'static>> UsbTransportBuilder<D> {
             ::embassy_usb::class::hid::HidSubclass::Boot,
             ::embassy_usb::class::hid::HidBootProtocol::Keyboard
         );
-        let other_writer = add_usb_writer!(&mut builder, CompositeReport, 9, 16);
+        let other_writer = add_usb_writer!(&mut builder, CompositeReport, COMPOSITE_WRITE_SIZE, 16);
         #[cfg(feature = "steno")]
         let steno_writer = add_usb_writer!(&mut builder, StenoReport, 9, 16);
         #[cfg(feature = "usb_log")]


### PR DESCRIPTION
The mouse report's 8-bit axes saturated at ±127 and dropped the surplus, which a 1600 CPI sensor reaches around 0.25 m/s at the 125 Hz default report rate; all four axes are now i16, matching ZMK.

BLE hosts bonded before this change cache the old report map, so they need re-pairing before the mouse works again.