### PR TITLE
fix(split): reserve sleep subscribers without display

### DIFF
--- a/rmk-config/src/default_config/subscriber_default.toml
+++ b/rmk-config/src/default_config/subscriber_default.toml
@@ -39,7 +39,6 @@ events = [
     # (gated on #[cfg(feature = "display")] in driver.rs)
     # Covers up to 2 peripherals; for 3+ peripherals override subs in keyboard.toml
     { name = "wpm_update", count = 2 },
-    { name = "sleep_state", count = 2 },
 ]
 
 # --- BLE-gated internal subscribers ---
@@ -123,6 +122,9 @@ events = [
     # split/driver.rs: ConnectionStatusChangeEvent::subscriber()
     # Covers up to 2 peripherals; for 3+ peripherals override subs in keyboard.toml
     { name = "connection_status_change", count = 2 },
+    # split/driver.rs: SleepStateEvent::subscriber()
+    # Covers up to 2 peripherals; for 3+ peripherals override subs in keyboard.toml
+    { name = "sleep_state", count = 2 },
 ]
 
 # --- Split + BLE-gated internal subscribers ---

--- a/rmk-config/src/resolved/build_constants.rs
+++ b/rmk-config/src/resolved/build_constants.rs
@@ -356,6 +356,31 @@ mod tests {
     }
 
     #[test]
+    fn split_reserves_sleep_subscribers_for_two_peripherals_without_display() {
+        let mut config: KeyboardTomlConfig = toml::from_str("").unwrap();
+        config.split = Some(SplitConfig {
+            peripheral: vec![SplitBoardConfig::default(), SplitBoardConfig::default()],
+            ..Default::default()
+        });
+        config.auto_calculate_parameters();
+
+        let sleep_subs = |features: &[&str]| {
+            config
+                .build_constants(features)
+                .unwrap()
+                .events
+                .into_iter()
+                .find(|event| event.name == "sleep_state")
+                .unwrap()
+                .subs
+        };
+        let base = sleep_subs(&[]);
+
+        assert_eq!(sleep_subs(&["split"]), base + 2);
+        assert_eq!(sleep_subs(&["split", "_ble"]), base + 4);
+    }
+
+    #[test]
     fn configless_split_has_no_battery_peripheral_ids() {
         let config: KeyboardTomlConfig = toml::from_str("").unwrap();
 


### PR DESCRIPTION
## Problem

Every split `PeripheralManager` now subscribes to `SleepStateEvent` regardless of the `display` feature, and each BLE central link adds a second sleep subscriber for connection-parameter updates. However, the two manager slots are still reserved only under `display + split`.

The shipped `nrf52840_ble_split_dongle` example has two peripherals and no display. Its generated `sleep_state` capacity is 3 slots, while the two managers plus two BLE link tasks need 4. When both peripherals connect, subscriber creation reaches the event macro `expect` and panics.

A regression test against the current resolver failed before the fix: serial split resolved 1 slot instead of the required base + 2.

## Fix

Move the existing two-slot `SleepStateEvent` reservation from `display + split` to every `split` build. Display builds keep the same total; non-display serial and BLE multi-split builds now reserve the manager subscribers they actually create.

## Tests

- `cargo test` in `rmk-config` (102 unit + 8 integration tests)
- `cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble` in `rmk` (523 passed)
- `cargo check --release --bin central` in `examples/use_config/nrf52840_ble_split_dongle`
- `bash scripts/format_all.sh`

## Risk

Low. The change only adds two subscriber slots to split builds without display; display builds keep their previous capacity. There is no protocol, persistence, or public API change. The PR changes 29 lines total (28 additions, 1 deletion).