### PR TITLE
fix(debounce): isolate fast debounce windows per key

### DIFF
--- a/rmk/src/debounce/fast_debouncer.rs
+++ b/rmk/src/debounce/fast_debouncer.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU16;
+
 use embassy_time::Instant;
 
 use super::{DebounceState, DebouncerTrait};
@@ -6,8 +8,7 @@ use crate::matrix::KeyState;
 
 /// Fast per-key debouncer.
 pub struct FastDebouncer<const ROW: usize, const COL: usize> {
-    last_ms: Instant,
-    debouncing: [[bool; ROW]; COL],
+    started_at: [[Option<NonZeroU16>; ROW]; COL],
 }
 
 impl<const ROW: usize, const COL: usize> Default for FastDebouncer<ROW, COL> {
@@ -20,8 +21,7 @@ impl<const ROW: usize, const COL: usize> FastDebouncer<ROW, COL> {
     /// Create a fast debouncer
     pub fn new() -> Self {
         FastDebouncer {
-            debouncing: [[false; ROW]; COL],
-            last_ms: Instant::now(),
+            started_at: [[None; ROW]; COL],
         }
     }
 }
@@ -35,12 +35,12 @@ impl<const ROW: usize, const COL: usize> DebouncerTrait<ROW, COL> for FastDeboun
         key_active: bool,
         key_state: &KeyState,
     ) -> DebounceState {
-        let debouncing = self.debouncing[col_idx][row_idx];
-        if debouncing {
+        if let Some(started_at) = self.started_at[col_idx][row_idx] {
             // Current key is in debouncing state
-            if self.last_ms.elapsed().as_millis() as u16 > DEBOUNCE_THRESHOLD {
+            let elapsed = (Instant::now().as_millis() as u16).wrapping_sub(started_at.get());
+            if elapsed > DEBOUNCE_THRESHOLD {
                 // If the elapsed time > DEBOUNCE_THRESHOLD, reset
-                self.debouncing[col_idx][row_idx] = false;
+                self.started_at[col_idx][row_idx] = None;
                 DebounceState::Ignored
             } else {
                 // Still in a debouncing progress
@@ -49,12 +49,44 @@ impl<const ROW: usize, const COL: usize> DebouncerTrait<ROW, COL> for FastDeboun
         } else if key_state.pressed != key_active {
             // If current key isn't in debouncing state, and a key change is detected
             // Trigger the key immediately and record current tick
-            self.last_ms = Instant::now();
-            // Change debouncing state
-            self.debouncing[col_idx][row_idx] = true;
+            let now = Instant::now().as_millis() as u16;
+            self.started_at[col_idx][row_idx] = Some(NonZeroU16::new(now).unwrap_or(NonZeroU16::MIN));
             DebounceState::Debounced
         } else {
             DebounceState::Ignored
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use embassy_time::{Duration, MockDriver};
+
+    use super::*;
+
+    #[test]
+    fn debounce_windows_are_per_key() {
+        MockDriver::get().reset();
+        MockDriver::get().advance(Duration::from_millis(1));
+
+        let mut debouncer = FastDebouncer::<1, 2>::new();
+        let released = KeyState::new();
+        assert!(matches!(
+            debouncer.detect_change_with_debounce(0, 0, true, &released),
+            DebounceState::Debounced
+        ));
+
+        MockDriver::get().advance(Duration::from_millis((DEBOUNCE_THRESHOLD - 1).into()));
+        assert!(matches!(
+            debouncer.detect_change_with_debounce(0, 1, true, &released),
+            DebounceState::Debounced
+        ));
+
+        MockDriver::get().advance(Duration::from_millis(2));
+        let pressed = KeyState { pressed: true };
+        assert!(matches!(
+            debouncer.detect_change_with_debounce(0, 0, false, &pressed),
+            DebounceState::Ignored
+        ));
     }
 }


### PR DESCRIPTION
## Problem

FastDebouncer stores a per-key active flag but uses one shared start timestamp. Any new key edge restarts that timestamp for every key that is already debouncing. Under rapid typing or chords, a release can therefore remain suppressed past its own debounce window and behave like a briefly stuck key.

## Evidence

The regression starts one key window, starts a second key near the end of the first window, then checks the first key after its own deadline. It fails on main because the second key moved the shared timestamp.

## Fix

Store the 16-bit start timestamp alongside each key state. This keeps the existing eager-edge and deferred-follow-up behavior while making the documented per-key isolation real.

## Validation

- Reproduced the regression on main with the focused nextest test
- cargo nextest run --no-default-features --features=split,vial,storage,async_matrix,_ble (524 passed)
- cargo check --no-default-features
- bash scripts/format_all.sh

## Risk

The fast debouncer now uses two bytes per matrix key instead of a per-key bool plus one shared Instant. Timing arithmetic and the 16-bit wrapping behavior match the default debouncer approach.